### PR TITLE
Define dbc fallback

### DIFF
--- a/app.py
+++ b/app.py
@@ -60,11 +60,14 @@ except ImportError as e:
         def __init__(self, children=None, **kwargs):
             self.children = children
             self.kwargs = kwargs
-        
+
         # Add themes attribute for fallback
         class themes:
             BOOTSTRAP = "mock-bootstrap"
-    
+
+    # Ensure a dbc fallback exists when dash_bootstrap_components is unavailable
+    dbc = _MockDBC
+
     class _MockDCC:
         def __init__(self, **kwargs):
             self.kwargs = kwargs


### PR DESCRIPTION
## Summary
- set `dbc` to `_MockDBC` when Dash dependencies aren't present
- ensure `dbc` is defined before use in `create_app`

## Testing
- `pytest -q` *(fails: ImportError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_68500ccd852883209cf8985f71313ace