### PR TITLE
Fix entity imports in models

### DIFF
--- a/models/__init__.py
+++ b/models/__init__.py
@@ -1,76 +1,24 @@
-# models/__init__.py - FIXED: Type-safe model imports
-"""
-Yōsai Intel Data Models Package - Type-safe and Modular
-"""
+# models/__init__.py - Simplified re-exports for models package
+"""Yōsai Intel Data Models Package"""
 
 # Import enums
-try:
-    from .enums import (
-        AnomalyType, AccessResult, BadgeStatus,
-        SeverityLevel, TicketStatus, DoorType
-    )
-except ImportError as e:
-    print(f"Warning: Could not import enums: {e}")
-    # Create fallback enums
-    from enum import Enum
-    class AnomalyType(Enum):
-        UNKNOWN = "unknown"
-    class AccessResult(Enum):
-        UNKNOWN = "unknown"
-    class BadgeStatus(Enum):
-        UNKNOWN = "unknown"
-    class SeverityLevel(Enum):
-        UNKNOWN = "unknown"
-    class TicketStatus(Enum):
-        UNKNOWN = "unknown"
-    class DoorType(Enum):
-        UNKNOWN = "unknown"
+from .enums import (
+    AnomalyType,
+    AccessResult,
+    BadgeStatus,
+    SeverityLevel,
+    TicketStatus,
+    DoorType,
+)
 
-# Import entities  
-try:
-    from .entities import Person, Door, Facility
-except ImportError as e:
-    print(f"Warning: Could not import entities: {e}")
-    # Create fallback classes
-    class Person:
-        pass
-    class Door:
-        pass
-    class Facility:
-        pass
+# Import entities
+from .entities import Person, Door, Facility
 
 # Import events
-try:
-    from .events import AccessEvent, AnomalyDetection, IncidentTicket
-except ImportError as e:
-    print(f"Warning: Could not import events: {e}")
-    # Create fallback classes
-    class AccessEvent:
-        pass
-    class AnomalyDetection:
-        pass
-    class IncidentTicket:
-        pass
+from .events import AccessEvent, AnomalyDetection, IncidentTicket
 
 # Import base models
-try:
-    from .base import BaseModel, AccessEventModel, AnomalyDetectionModel, ModelFactory
-except ImportError as e:
-    print(f"Warning: Could not import base models: {e}")
-    # Create fallback classes
-    class BaseModel:
-        pass
-    class AccessEventModel:
-        pass
-    class AnomalyDetectionModel:
-        pass
-    class ModelFactory:
-        @staticmethod
-        def create_access_model(db_connection):
-            return AccessEventModel()
-        @staticmethod
-        def create_anomaly_model(db_connection):
-            return AnomalyDetectionModel()
+from .base import BaseModel, AccessEventModel, AnomalyDetectionModel, ModelFactory
 
 # Define exports
 __all__ = [


### PR DESCRIPTION
## Summary
- simplify `models` imports and remove fallback classes

## Testing
- `python -m py_compile models/__init__.py`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_68500ccea3e48320b7f1763e8579d0d8