### PR TITLE
Fix Pylance deps & update docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,9 @@ yosai_intel_dashboard/
    ```bash
    pip install -r requirements.txt
    ```
+   Make sure all dependencies are installed **before** running Pyright or using
+   the Pylance extension. Missing packages will otherwise appear as unresolved
+   imports.
 
 4. **Set up environment:**
    ```bash

--- a/requirements.txt
+++ b/requirements.txt
@@ -45,3 +45,7 @@ sentry-sdk[flask]>=1.32.0
 # Geographic/Map (optional)
 geopandas>=0.13.0
 shapely>=2.0.0
+dash-leaflet>=1.0.0
+
+# CSS Utilities (optional)
+cssutils>=2.6.0


### PR DESCRIPTION
## Summary
- add missing packages `dash-leaflet` and `cssutils`
- mention that dependencies must be installed before running Pyright or Pylance

## Testing
- `pytest -q` *(fails: cannot import 'MockDatabaseConnection' and ModuleNotFoundError: No module named 'pandas')*
- `pyright` *(fails to resolve imports due to missing packages)*

------
https://chatgpt.com/codex/tasks/task_e_68500cd0a0348320ace8e146e86d603a