### PR TITLE
Refactor optional imports for better type checking

### DIFF
--- a/components/analytics/data_preview.py
+++ b/components/analytics/data_preview.py
@@ -4,11 +4,17 @@ Data preview component for analytics page
 FIXED: Properly exports create_data_preview function
 """
 
+from typing import Any, Optional, List, TYPE_CHECKING
+
+if TYPE_CHECKING:
+    import dash_bootstrap_components as dbc
+    from dash import html
+    import pandas as pd
+
 try:
     import dash_bootstrap_components as dbc
     from dash import html
     import pandas as pd
-    from typing import Optional, List
     DASH_AVAILABLE = True
 except ImportError:
     print("Warning: Dash components not available in data_preview")
@@ -18,9 +24,7 @@ except ImportError:
     html = None
     pd = None
 
-from typing import Any
-
-def create_data_preview(df: Optional[pd.DataFrame] = None, filename: str = "") -> Any:
+def create_data_preview(df: Optional['pd.DataFrame'] = None, filename: str = "") -> Any:
     """Create data preview component - FIXED: Properly exported function"""
 
     if not DASH_AVAILABLE or html is None or dbc is None:
@@ -51,7 +55,7 @@ def create_data_preview(df: Optional[pd.DataFrame] = None, filename: str = "") -
         ], className="mb-4")
     ])
 
-def _create_type_safe_table(df: pd.DataFrame) -> Any:
+def _create_type_safe_table(df: 'pd.DataFrame') -> Any:
     """Create a completely type-safe HTML table"""
 
     if not DASH_AVAILABLE or html is None or dbc is None or pd is None or df.empty:
@@ -163,7 +167,7 @@ def _create_type_safe_table(df: pd.DataFrame) -> Any:
     
     return html.Div(result_components)
 
-def create_dataset_summary(df: pd.DataFrame) -> Any:
+def create_dataset_summary(df: 'pd.DataFrame') -> Any:
     """Create dataset summary with guaranteed type safety"""
 
     if not DASH_AVAILABLE or html is None or dbc is None or pd is None or df.empty:
@@ -196,7 +200,7 @@ def create_dataset_summary(df: pd.DataFrame) -> Any:
         html.Div(summary_items, className="summary-list text-muted", style={'fontSize': '0.9rem'})
     ])
 
-def create_enhanced_preview(df: Optional[pd.DataFrame] = None, filename: str = "") -> Any:
+def create_enhanced_preview(df: Optional['pd.DataFrame'] = None, filename: str = "") -> Any:
     """Enhanced preview with summary - completely type safe"""
 
     if not DASH_AVAILABLE or html is None or dbc is None or pd is None:

--- a/components/navbar.py
+++ b/components/navbar.py
@@ -3,10 +3,16 @@
 Navigation bar component with complete type safety
 """
 
+import datetime
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    import dash_bootstrap_components as dbc
+    from dash import html, dcc, callback, Output, Input
+
 try:
     import dash_bootstrap_components as dbc
     from dash import html, dcc, callback, Output, Input
-    import datetime
     DASH_AVAILABLE = True
 except ImportError:
     print("Warning: Dash components not available")
@@ -15,6 +21,9 @@ except ImportError:
     dbc = None
     html = None
     dcc = None
+    callback = None
+    Output = None
+    Input = None
 
 def create_navbar_layout():
     """Create navbar layout with fallback"""

--- a/config/database_manager.py
+++ b/config/database_manager.py
@@ -6,10 +6,15 @@ Handles connection pooling, configuration, and error management
 
 import os
 import logging
-from typing import Optional, Dict, Any, Union
+from typing import Optional, Dict, Any, Union, TYPE_CHECKING
 from contextlib import contextmanager
 from dataclasses import dataclass
 import pandas as pd
+
+if TYPE_CHECKING:
+    import psycopg2
+    from psycopg2 import pool
+    import sqlite3
 
 # Optional imports with fallbacks
 try:
@@ -43,8 +48,8 @@ class DatabaseConfig:
 
 class DatabaseConnection:
     """Abstract database connection interface"""
-    
-    def execute_query(self, query: str, params: Optional[tuple] = None) -> pd.DataFrame:
+
+    def execute_query(self, query: str, params: Optional[tuple] = None) -> 'pd.DataFrame':
         raise NotImplementedError
     
     def execute_command(self, command: str, params: Optional[tuple] = None) -> None:
@@ -61,7 +66,7 @@ class PostgreSQLConnection(DatabaseConnection):
             raise ImportError("psycopg2 not available. Install with: pip install psycopg2-binary")
         
         self.config = config
-        self.connection_pool: Optional[pool.SimpleConnectionPool] = None
+        self.connection_pool: Optional['pool.SimpleConnectionPool'] = None
         self._initialize_pool()
     
     def _initialize_pool(self) -> None:
@@ -99,7 +104,7 @@ class PostgreSQLConnection(DatabaseConnection):
             if conn:
                 self.connection_pool.putconn(conn)
     
-    def execute_query(self, query: str, params: Optional[tuple] = None) -> pd.DataFrame:
+    def execute_query(self, query: str, params: Optional[tuple] = None) -> 'pd.DataFrame':
         """Execute SELECT query and return DataFrame"""
         try:
             with self.get_connection() as conn:
@@ -160,7 +165,7 @@ class SQLiteConnection(DatabaseConnection):
             logging.error(f"SQLite initialization failed: {e}")
             raise
     
-    def execute_query(self, query: str, params: Optional[tuple] = None) -> pd.DataFrame:
+    def execute_query(self, query: str, params: Optional[tuple] = None) -> 'pd.DataFrame':
         """Execute query and return DataFrame"""
         try:
             conn = sqlite3.connect(self.db_path)
@@ -193,7 +198,7 @@ class MockDatabaseConnection(DatabaseConnection):
         self.sample_data = self._generate_sample_data()
         logging.info("Mock database connection initialized")
     
-    def _generate_sample_data(self) -> Dict[str, pd.DataFrame]:
+    def _generate_sample_data(self) -> Dict[str, 'pd.DataFrame']:
         """Generate sample data for testing"""
         from datetime import datetime, timedelta
         
@@ -208,7 +213,7 @@ class MockDatabaseConnection(DatabaseConnection):
         
         return {'access_events': access_events}
     
-    def execute_query(self, query: str, params: Optional[tuple] = None) -> pd.DataFrame:
+    def execute_query(self, query: str, params: Optional[tuple] = None) -> 'pd.DataFrame':
         """Mock query execution"""
         # Simple query simulation
         if "access_events" in query.lower():


### PR DESCRIPTION
## Summary
- ensure optional imports use TYPE_CHECKING so type checkers see them
- keep runtime fallbacks for missing libraries
- update type hints to use string annotations

## Testing
- `python test_modular_system.py` *(fails: ModuleNotFoundError: No module named 'pandas')*
- `pytest` *(fails: 5 errors during collection)*
- `mypy .` *(fails: found 222 errors)*
- `black . --check` *(fails: would reformat files)*
- `flake8 .` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685010e0438c8320bb6802a6feabc565