### PR TITLE
Remove unused openpyxl import

### DIFF
--- a/services/file_processor.py
+++ b/services/file_processor.py
@@ -6,7 +6,6 @@ import uuid
 from typing import Dict, Any, Optional, Tuple, Sequence
 import logging
 from datetime import datetime
-import openpyxl
 
 class FileProcessor:
     """Service for processing uploaded files"""


### PR DESCRIPTION
## Summary
- remove unused openpyxl import from `file_processor`

## Testing
- `python test_modular_system.py` *(fails: ModuleNotFoundError: No module named 'pandas')*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*
- `mypy .` *(fails: Cannot find implementation or library stub for module named 'dash_bootstrap_components', etc.)*
- `flake8 services/file_processor.py` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6850175f5c448320951a448d7a736652