### PR TITLE
Add docstring for services package

### DIFF
--- a/services/__init__.py
+++ b/services/__init__.py
@@ -1,1 +1,7 @@
+# services/__init__.py
+"""Service layer for analytics and file handling utilities."""
 
+from .analytics_service import AnalyticsService
+from .file_processor import FileProcessor
+
+__all__ = ["AnalyticsService", "FileProcessor"]


### PR DESCRIPTION
## Summary
- add basic docstring to `services` package
- export `AnalyticsService` and `FileProcessor` for convenience

## Testing
- `python test_modular_system.py` *(fails: No module named 'pandas')*
- `pytest` *(fails: ModuleNotFoundError: No module named 'pandas')*
- `mypy .` *(fails: import-not-found errors)*
- `black . --check` *(fails: would reformat many files)*
- `flake8 .` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68501766980c832088c25aa3302b964b