### PR TITLE
Fix fallback class names

### DIFF
--- a/pages/deep_analytics.py
+++ b/pages/deep_analytics.py
@@ -37,7 +37,7 @@ except ImportError as e:
     def create_summary_cards(*args, **kwargs):
         return html.Div("Summary cards not available")
     
-    class FileProcessor:
+    class FallbackFileProcessor:
         @staticmethod
         def process_file_content(contents, filename):
             return None
@@ -45,11 +45,17 @@ except ImportError as e:
         def validate_dataframe(df):
             return False, "FileProcessor not available", []
     
-    class AnalyticsGenerator:
+
+    class FallbackAnalyticsGenerator:
         @staticmethod
         def generate_analytics(df):
             return {}
 
+
+# Assign fallback classes to main names if analytics components are unavailable
+if not ANALYTICS_COMPONENTS_AVAILABLE:
+    FileProcessor = FallbackFileProcessor
+    AnalyticsGenerator = FallbackAnalyticsGenerator
 def layout():
     """Deep Analytics page layout - same as before"""
     return dbc.Container([


### PR DESCRIPTION
## Summary
- rename fallback classes in `deep_analytics` to `FallbackFileProcessor` and `FallbackAnalyticsGenerator`
- define global aliases to these fallbacks when components are missing

## Testing
- `python test_modular_system.py` *(fails: No module named 'pandas')*
- `mypy .` *(fails: found 234 errors)*
- `flake8 .` *(fails: command not found)*
- `black . --check` *(fails: many files would be reformatted)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_685022fabb18832090619573869cda9d