### PR TITLE
Fix ServiceDefinition dependencies default

### DIFF
--- a/core/container.py
+++ b/core/container.py
@@ -1,7 +1,7 @@
 # core/container.py
 """Dependency Injection Container for Yōsai Intel Dashboard"""
 from typing import Dict, Any, TypeVar, Callable, Optional, List
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 import threading
 import logging
 
@@ -13,7 +13,7 @@ class ServiceDefinition:
     """Definition of a registered service"""
     factory: Callable[..., Any]
     singleton: bool = True
-    dependencies: List[str] = None
+    dependencies: List[str] = field(default_factory=list)
 
 class Container:
     """Simple but powerful dependency injection container"""


### PR DESCRIPTION
## Summary
- use `dataclass, field` import in `core/container.py`
- give `ServiceDefinition.dependencies` a `field(default_factory=list)`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_68502405c3488320b514860d536caf13