### PR TITLE
Update env example and docs

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -3,38 +3,38 @@
 # These variables override values in config/config.yaml
 
 # Application Configuration
-YOSAI_APP_DEBUG=true
-YOSAI_APP_HOST=127.0.0.1
-YOSAI_APP_PORT=8050
-YOSAI_APP_LOG_LEVEL=INFO
+DEBUG=true
+APP_HOST=127.0.0.1
+PORT=8050
+LOG_LEVEL=INFO
 
 # Database Configuration
-YOSAI_DATABASE_TYPE=mock
-YOSAI_DATABASE_HOST=localhost
-YOSAI_DATABASE_PORT=5432
-YOSAI_DATABASE_DATABASE=yosai_intel
-YOSAI_DATABASE_USERNAME=postgres
-YOSAI_DATABASE_PASSWORD=your_password_here
+DB_TYPE=mock
+DB_HOST=localhost
+DB_PORT=5432
+DB_NAME=yosai_intel
+DB_USER=postgres
+DB_PASSWORD=your_password_here
 
 # Cache Configuration
-YOSAI_CACHE_TYPE=memory
-YOSAI_CACHE_HOST=localhost
-YOSAI_CACHE_PORT=6379
+CACHE_TYPE=memory
+REDIS_HOST=localhost
+REDIS_PORT=6379
 
 # Security Configuration
-YOSAI_SECURITY_SECRET_KEY=your-secret-key-here
-YOSAI_SECURITY_MAX_FILE_SIZE_MB=100
+SECRET_KEY=your-secret-key-here
+MAX_FILE_SIZE_MB=100
 
 # Analytics Configuration
-YOSAI_ANALYTICS_ENABLE_REAL_TIME=true
-YOSAI_ANALYTICS_MAX_RECORDS_PER_QUERY=10000
+ENABLE_REAL_TIME=true
+MAX_RECORDS_PER_QUERY=10000
 
 # Monitoring Configuration
-YOSAI_MONITORING_HEALTH_CHECK_ENABLED=true
-YOSAI_MONITORING_METRICS_ENABLED=true
+HEALTH_CHECK_ENABLED=true
+METRICS_ENABLED=true
 
 # Production-specific variables (uncomment for production)
-# YOSAI_DATABASE_TYPE=postgresql
-# YOSAI_CACHE_TYPE=redis
-# YOSAI_APP_DEBUG=false
-# YOSAI_MONITORING_SENTRY_DSN=your_sentry_dsn_here
+# DB_TYPE=postgresql
+# CACHE_TYPE=redis
+# DEBUG=false
+# SENTRY_DSN=your_sentry_dsn_here

--- a/README.md
+++ b/README.md
@@ -145,6 +145,27 @@ PORT=8050            # Application port
 SECRET_KEY=your-key  # Change for production
 ```
 
+### Environment Overrides
+
+`ConfigurationManager` loads YAML files from `config/` and then checks for
+environment variables. When a variable name matches a key used in the YAML
+configuration (for example `DB_HOST`, `DB_USER`, `REDIS_HOST` or
+`SECRET_KEY`), its value replaces the one from the file. This lets you adjust
+settings without editing the YAML files.
+
+Example:
+
+```bash
+DB_HOST=localhost
+DB_USER=postgres
+REDIS_HOST=localhost
+SECRET_KEY=supersecret
+python app.py
+```
+
+These values override `database.host`, `database.username`, `cache.host` and
+`security.secret_key` from the loaded YAML.
+
 ## 📊 Modular Components
 
 ### Database Layer (`config/`)


### PR DESCRIPTION
## Summary
- rename variables in `.env.example` to match YAML files
- explain environment overrides in `README.md`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*
- `flake8 .` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6850a5422cd08320babf0e9e0c0ce615