### PR TITLE
Resolve missing imports for DI verification scripts

### DIFF
--- a/core/app_factory.py
+++ b/core/app_factory.py
@@ -150,6 +150,14 @@ def create_application(config_path: Optional[str] = None) -> Optional[YosaiDash]
         logger.error(f"Error creating application: {e}")
         return None
 
+def create_application_for_testing() -> Optional[YosaiDash]:
+    """Create application instance configured for unit tests."""
+    try:
+        return create_application(None)
+    except Exception as e:
+        logger.error(f"Error creating test application: {e}")
+        return None
+
 # ============================================================================
 # COMPLETE YAML CONFIGURATION SYSTEM SUMMARY
 """
@@ -319,7 +327,8 @@ if __name__ == "__main__":
 # Export main functions
 __all__ = [
     'create_application',
-    'DashAppFactory', 
+    'create_application_for_testing',
+    'DashAppFactory',
     'YosaiDash',
     'verify_yaml_system'
 ]

--- a/core/service_registry.py
+++ b/core/service_registry.py
@@ -317,8 +317,12 @@ def get_configured_container_with_yaml() -> Container:
     # Configure if not already configured
     if not container.has('config_manager'):
         configure_container_with_yaml(container)
-    
+
     return container
+
+def get_configured_container() -> Container:
+    """Legacy wrapper for backward compatibility"""
+    return get_configured_container_with_yaml()
 
 # ============================================================================
 # tests/test_yaml_configuration.py - NEW: Comprehensive configuration testing
@@ -555,6 +559,7 @@ if __name__ == "__main__":
 __all__ = [
     'configure_container_with_yaml',
     'get_configured_container_with_yaml',
+    'get_configured_container',
     'EnhancedHealthMonitor',
     'run_configuration_tests'
 ]

--- a/verify_yaml_config.py
+++ b/verify_yaml_config.py
@@ -219,7 +219,7 @@ def test_dependency_injection_integration() -> Tuple[bool, str]:
         
         # Create container and configure it
         container = Container()
-        configure_container_with_yaml(container, config_manager)
+        configure_container_with_yaml(container)
         
         # Verify configuration objects are registered
         required_services = [
@@ -395,7 +395,7 @@ def print_summary(results: List[Tuple[str, bool, str]]) -> None:
         print(f"   3. Check for syntax errors in config files")
         print(f"   4. Verify directory structure")
 
-def main() -> None:
+def main() -> int:
     """Main verification function"""
     print("🏯 YŌSAI INTEL DASHBOARD")
     print("🔧 Priority 3: Configuration Management Verification")


### PR DESCRIPTION
## Summary
- provide `get_configured_container()` wrapper in service registry
- expose new helper in `__all__`
- implement `create_application_for_testing()` in app factory
- expose testing helper from app factory
- fix DI configuration call in YAML verification
- correct return type of YAML verification `main`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'dash')*
- `flake8` *(fails: command not found)*
- `mypy` *(fails: Missing target module)*

------
https://chatgpt.com/codex/tasks/task_e_6850aa70ffcc8320bf6192d16a614e86