### PR TITLE
Fix DI container check in tests

### DIFF
--- a/test_dependency_injection.py
+++ b/test_dependency_injection.py
@@ -155,7 +155,7 @@ def test_app_creation_with_di():
             # Check that container is attached
             if hasattr(app, '_yosai_container'):
                 container = app._yosai_container
-                if container.has('config'):
+                if container is not None and container.has('config'):
                     print("✅ App created with DI container successfully")
                     return True
                 else:


### PR DESCRIPTION
## Summary
- update `test_dependency_injection` so container existence is verified before accessing it

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_6850b1971d6c8320bd9f1f9cac9a3b01