### PR TITLE
Fix relative imports in test container

### DIFF
--- a/tests/tests/test_di_container.py
+++ b/tests/tests/test_di_container.py
@@ -264,9 +264,9 @@ Enhanced callback manager with improved DI container access
 from typing import Any, Optional, Callable
 import logging
 from functools import wraps
-from .component_registry import ComponentRegistry
-from .layout_manager import LayoutManager
-from .container import Container
+from core.component_registry import ComponentRegistry
+from core.layout_manager import LayoutManager
+from core.container import Container
 
 logger = logging.getLogger(__name__)
 


### PR DESCRIPTION
## Summary
- fix relative imports in `tests/tests/test_di_container.py`

## Testing
- `pytest tests/tests/test_di_container.py -vv --maxfail=1` *(fails: ModuleNotFoundError: No module named 'core')*

------
https://chatgpt.com/codex/tasks/task_e_6850b1f40d0883209773c315553bec9d