### PR TITLE
Fix inject_services to use Dash app API

### DIFF
--- a/tests/tests/test_di_container.py
+++ b/tests/tests/test_di_container.py
@@ -276,29 +276,25 @@ def inject_services(*service_names: str):
         @wraps(callback_func)
         def wrapper(*args, **kwargs):
             # Get container from current app context
-            from dash import callback_context
-            
+            from dash import Dash, callback_context
+
             if hasattr(callback_context, 'triggered_prop_ids'):
-                # We're in a callback context, try to get app
                 try:
-                    import dash
-                    current_app = dash.current_app
-                    
-                    if hasattr(current_app, 'get_service'):
-                        # Inject requested services
-                        services = {}
-                        for service_name in service_names:
-                            try:
-                                services[service_name] = current_app.get_service(service_name)
-                            except Exception as e:
-                                logger.warning(f"Could not inject service {service_name}: {e}")
-                                services[service_name] = None
-                        
-                        # Add services to kwargs
-                        kwargs.update(services)
-                
+                    current_app = Dash._get_app()
                 except Exception as e:
-                    logger.warning(f"Could not inject services: {e}")
+                    logger.warning(f"Could not retrieve Dash app: {e}")
+                    current_app = None
+
+                if current_app and hasattr(current_app, 'get_service'):
+                    services = {}
+                    for service_name in service_names:
+                        try:
+                            services[service_name] = current_app.get_service(service_name)
+                        except Exception as e:
+                            logger.warning(f"Could not inject service {service_name}: {e}")
+                            services[service_name] = None
+
+                    kwargs.update(services)
             
             return callback_func(*args, **kwargs)
         return wrapper


### PR DESCRIPTION
## Summary
- update inject_services decorator to retrieve Dash app via Dash._get_app

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas' and 'dash')*

------
https://chatgpt.com/codex/tasks/task_e_6850b1f4ffd08320854c904aaf50d3ed