### PR TITLE
Implement container test_scope helper

### DIFF
--- a/core/container.py
+++ b/core/container.py
@@ -4,6 +4,7 @@ from typing import Dict, Any, TypeVar, Callable, Optional, List
 from dataclasses import dataclass, field
 import threading
 import logging
+from contextlib import contextmanager
 
 T = TypeVar('T')
 logger = logging.getLogger(__name__)
@@ -124,6 +125,17 @@ class Container:
                 stop_method = getattr(instance, "stop", None)
                 if callable(stop_method):
                     stop_method()
+
+    @contextmanager
+    def test_scope(self):
+        """Temporarily isolate service registrations for testing."""
+        saved_services = dict(self._services)
+        saved_instances = dict(self._instances)
+        try:
+            yield self
+        finally:
+            self._services = saved_services
+            self._instances = saved_instances
 
     def health_check(self) -> Dict[str, str]:
         """Simple health check for the container."""

--- a/tests/test_container_scope.py
+++ b/tests/test_container_scope.py
@@ -1,0 +1,17 @@
+import unittest
+from core.container import Container
+
+class TestContainerScope(unittest.TestCase):
+    def test_test_scope_restores_state(self):
+        container = Container()
+        container.register('service', lambda: {'name': 'prod'})
+        prod_instance = container.get('service')
+
+        with container.test_scope():
+            container.register('service', lambda: {'name': 'test'})
+            self.assertEqual(container.get('service')['name'], 'test')
+
+        self.assertIs(container.get('service'), prod_instance)
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary
- add `test_scope` context manager to `Container`
- unit test for the new test scope helper

## Testing
- `pytest tests/test_container_scope.py -q` *(fails: ModuleNotFoundError: No module named 'dash')*

------
https://chatgpt.com/codex/tasks/task_e_6850b1f634288320be37358e512ca2a6