### PR TITLE
Implement extended container health check

### DIFF
--- a/core/container.py
+++ b/core/container.py
@@ -125,9 +125,14 @@ class Container:
                 if callable(stop_method):
                     stop_method()
 
-    def health_check(self) -> Dict[str, str]:
+    def health_check(self) -> Dict[str, Any]:
         """Simple health check for the container."""
-        return {"status": "healthy"}
+        return {
+            "status": "healthy",
+            "services_registered": len(self._services),
+            "instances_created": len(self._instances),
+            "started": True,
+        }
 
 # Global container instance
 _container: Optional[Container] = None


### PR DESCRIPTION
## Summary
- extend `Container.health_check` to provide more metrics

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_6850b1f799488320b408843b8db0e74c