### PR TITLE
Fix imports and add missing service stubs

### DIFF
--- a/core/enhanced_container.py
+++ b/core/enhanced_container.py
@@ -439,6 +439,9 @@ Enhanced service registry using the new container features
 
 from .enhanced_container import EnhancedContainer, LifecycleScope
 from .providers import SingletonProvider, FactoryProvider, ConfigurationProvider
+from services.analytics_service import create_analytics_service
+from services.database_service import create_database_connection
+from services.cache_manager import EnhancedCacheManager
 
 def create_production_container() -> EnhancedContainer:
     """Create production-ready container with all features"""

--- a/services/__init__.py
+++ b/services/__init__.py
@@ -1,7 +1,15 @@
 # services/__init__.py
 """Service layer for analytics and file handling utilities."""
 
-from .analytics_service import AnalyticsService
+from .analytics_service import AnalyticsService, create_analytics_service
 from .file_processor import FileProcessor
+from .cache_manager import EnhancedCacheManager
+from .database_service import create_database_connection
 
-__all__ = ["AnalyticsService", "FileProcessor"]
+__all__ = [
+    "AnalyticsService",
+    "create_analytics_service",
+    "FileProcessor",
+    "EnhancedCacheManager",
+    "create_database_connection",
+]

--- a/services/cache_manager.py
+++ b/services/cache_manager.py
@@ -1,0 +1,26 @@
+from typing import Any, Optional
+import logging
+
+logger = logging.getLogger(__name__)
+
+class EnhancedCacheManager:
+    """Minimal cache manager used by the enhanced container."""
+    def __init__(self, config: Optional[Any] = None) -> None:
+        self.config = config
+        self._cache = {}
+
+    def get(self, key: str) -> Any:
+        return self._cache.get(key)
+
+    def set(self, key: str, value: Any, timeout: Optional[int] = None) -> None:
+        self._cache[key] = value
+
+    def clear(self) -> None:
+        self._cache.clear()
+
+    def start(self) -> None:
+        logger.info("Enhanced cache manager started")
+
+    def stop(self) -> None:
+        logger.info("Enhanced cache manager stopped")
+        self.clear()

--- a/services/database_service.py
+++ b/services/database_service.py
@@ -1,0 +1,7 @@
+from typing import Any, Optional
+from config.database_manager import DatabaseManager, DatabaseConfig
+
+
+def create_database_connection(config: Optional[DatabaseConfig] = None) -> Any:
+    """Create a database connection using DatabaseManager."""
+    return DatabaseManager.create_connection(config)


### PR DESCRIPTION
## Summary
- add minimal `EnhancedCacheManager` and `create_database_connection` services
- export them from the services package
- import new services in `core/enhanced_container.py`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_6850d084cd10832099fe6d8000640602