### PR TITLE
Add missing import

### DIFF
--- a/core/service_registry.py
+++ b/core/service_registry.py
@@ -6,6 +6,7 @@ from typing import Any
 import logging
 from .container import Container, get_container
 from config.yaml_config import ConfigurationManager, get_configuration_manager
+import sys
 
 logger = logging.getLogger(__name__)
 


### PR DESCRIPTION
## Summary
- import `sys` in core/service_registry.py

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas', 'dash')*

------
https://chatgpt.com/codex/tasks/task_e_6850d087516483209750a3af7c81362d