### PR TITLE
Fix example imports in enhanced container

### DIFF
--- a/core/enhanced_container.py
+++ b/core/enhanced_container.py
@@ -437,6 +437,11 @@ Enhanced service registry using the new container features
 """
 
 from .enhanced_container import EnhancedContainer, LifecycleScope
+from .service_registry import (
+    create_database_with_yaml_config,
+    create_cache_with_yaml_config,
+    create_analytics_service_with_config,
+)
 
 def create_production_container() -> EnhancedContainer:
     """Create production-ready container with all features"""
@@ -453,7 +458,7 @@ def create_production_container() -> EnhancedContainer:
     # Register database with lifecycle management
     container.register(
         'database',
-        create_database_connection,
+        create_database_with_yaml_config,
         scope=LifecycleScope.SINGLETON,
         dependencies=['config'],
         lifecycle=True,
@@ -464,7 +469,7 @@ def create_production_container() -> EnhancedContainer:
     # Register cache manager with request scope for web apps
     container.register(
         'cache_manager',
-        EnhancedCacheManager,
+        create_cache_with_yaml_config,
         scope=LifecycleScope.REQUEST,
         dependencies=['config'],
         lifecycle=True,
@@ -474,7 +479,7 @@ def create_production_container() -> EnhancedContainer:
     # Register analytics service with high priority
     container.register(
         'analytics_service',
-        create_analytics_service,
+        create_analytics_service_with_config,
         scope=LifecycleScope.SINGLETON,
         dependencies=['access_model', 'anomaly_model', 'config', 'cache_manager'],
         tags=['business', 'analytics'],


### PR DESCRIPTION
## Summary
- fix usage example by importing correct service registry implementations
- register cache, database, and analytics services with real factories

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_6850fe81ca648320bec2b9ea79279be0