### PR TITLE
Implement test_scope for DI container

### DIFF
--- a/core/container.py
+++ b/core/container.py
@@ -103,6 +103,17 @@ class Container:
         self._services.clear()
         self._instances.clear()
         logger.debug("Container cleared")
+
+    @contextmanager
+    def test_scope(self):
+        """Temporarily isolate registrations and instances for testing"""
+        saved_services = self._services.copy()
+        saved_instances = self._instances.copy()
+        try:
+            yield self
+        finally:
+            self._services = saved_services
+            self._instances = saved_instances
     
     def list_services(self) -> List[str]:
         """List all registered services"""


### PR DESCRIPTION
## Summary
- add `test_scope` context manager to `Container`
- ensure file ends cleanly without shell artifacts

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas' and 'dash')*

------
https://chatgpt.com/codex/tasks/task_e_6850fe327d9c8320a33039633d889716