### PR TITLE
Fix StringIO import in yaml_config_cli

### DIFF
--- a/yaml_config_cli.py
+++ b/yaml_config_cli.py
@@ -11,6 +11,7 @@ Python Version: 3.8+
 """
 
 import unittest
+import io
 import tempfile
 import os
 import yaml
@@ -600,7 +601,7 @@ class ConfigurationTestRunner:
         suite = loader.loadTestsFromTestCase(suite_class)
         
         # Capture test results
-        stream = unittest.StringIO()
+        stream = io.StringIO()
         runner = unittest.TextTestRunner(stream=stream, verbosity=2 if verbose else 1)
         result = runner.run(suite)
         


### PR DESCRIPTION
## Summary
- import `io` to use `StringIO`
- use `io.StringIO` when capturing test runner output

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_6851025b7938832099541c7a6212556c