### PR TITLE
Fix syntax errors

### DIFF
--- a/create_yaml_config_files.py
+++ b/create_yaml_config_files.py
@@ -1207,7 +1207,7 @@ def test_yaml_file_loading() -> Tuple[bool, str]:
         from config.yaml_config import ConfigurationManager
         
         # Create test YAML config manually (no PyYAML dependency)
-        test_config_text = '''app:
+        test_config_text = """app:
   debug: false
   host: 0.0.0.0
   port: 9000
@@ -1219,7 +1219,7 @@ database:
 cache:
   type: redis
   timeout_seconds: 600
-'''
+"""
         
         # Write to temporary file
         with tempfile.NamedTemporaryFile(mode='w', suffix='.yaml', delete=False) as f:

--- a/simple_verify_di.py
+++ b/simple_verify_di.py
@@ -22,7 +22,8 @@ def test_service_registry():
     """Test service registry imports"""
     print("\n🔍 Testing service registry...")
     try:
-        from core.service_registry import get_configured_container        print("   ✅ get_configured_container_with_yaml - OK")
+        from core.service_registry import get_configured_container
+        print("   ✅ get_configured_container_with_yaml - OK")
         return True
     except ImportError as e:
         print(f"   ❌ get_configured_container_with_yaml - FAILED: {e}")

--- a/tools/code_quality.py
+++ b/tools/code_quality.py
@@ -665,10 +665,11 @@ class CodeQualityAnalyzer:
         for rec in report.recommendations:
             md += f"- {rec}\n"
         
-        md += f"\n## Metrics
-- **Functions Analyzed**: {report.metrics.get('functions_analyzed', 0)}
-- **Classes Analyzed**: {report.metrics.get('classes_analyzed', 0)}
-"""
+        md += (
+            f"\n## Metrics\n"
+            f"- **Functions Analyzed**: {report.metrics.get('functions_analyzed', 0)}\n"
+            f"- **Classes Analyzed**: {report.metrics.get('classes_analyzed', 0)}\n"
+        )
         
         if report.metrics.get('function_lengths'):
             avg_func_length = sum(report.metrics['function_lengths']) / len(report.metrics['function_lengths'])


### PR DESCRIPTION
## Summary
- fix newline for service registry check in `simple_verify_di.py`
- correct f-string assembly in `tools/code_quality.py`
- use triple quotes for YAML text in `create_yaml_config_files.py`

## Testing
- `python3 -m py_compile $(find . -name "*.py" ! -name verify_di_fix.py)`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_68514fc2899883208cb9d77e56ecdc3d