### PR TITLE
Fix analytics service registration with optional dependencies

### DIFF
--- a/core/__init__.py
+++ b/core/__init__.py
@@ -6,18 +6,25 @@ Your current DI implementation is perfect - no changes needed!
 
 from .container import Container, get_container, reset_container
 from .config_manager import ConfigManager
-from .app_factory import create_application
+
+try:
+    from .app_factory import create_application
+except Exception:  # pragma: no cover - optional dependency
+    create_application = None  # type: ignore
+
 from .service_registry import get_configured_container
 
 # Export public API
 __all__ = [
     'Container',
-    'get_container', 
+    'get_container',
     'reset_container',
     'ConfigManager',
-    'create_application',
     'get_configured_container'
 ]
+
+if create_application is not None:
+    __all__.insert(4, 'create_application')
 
 # Version info
 __version__ = '1.0.0'
@@ -50,4 +57,4 @@ def verify_di_system():
 # Quick test on import
 if __name__ == "__main__":
     status = verify_di_system()
-    print(f"DI Status: {status['message']}")
+    print(f"DI Status: {status["message"]}")

--- a/core/service_registry_fixed.py
+++ b/core/service_registry_fixed.py
@@ -156,11 +156,18 @@ def configure_container_fixed(container: Container, config_manager: Optional[Any
     
     # Layer 4: Business services (FIXED - minimal dependencies)
     logger.info("   ⚙️ Layer 4: Business services...")
-    container.register(
-        'analytics_service',
-        lambda analytics_config: create_analytics_service_simple(analytics_config),
-        dependencies=['analytics_config'] if config_manager else []
-    )
+    if config_manager:
+        container.register(
+            'analytics_service',
+            lambda analytics_config: create_analytics_service_simple(analytics_config),
+            dependencies=['analytics_config']
+        )
+    else:
+        container.register(
+            'analytics_service',
+            lambda: create_analytics_service_simple(None),
+            dependencies=[]
+        )
     
     # Layer 5: Monitoring services
     logger.info("   📈 Layer 5: Monitoring services...")


### PR DESCRIPTION
## Summary
- avoid importing Dash app factory when Dash isn't installed
- register `analytics_service` without missing dependency when no config manager

## Testing
- `python working_check_services.py`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_685164004eb08320934a4061d6fa431c