### PR TITLE
Fix DI container calls and add YAML startup info

### DIFF
--- a/config/yaml_config.py
+++ b/config/yaml_config.py
@@ -401,6 +401,19 @@ class ConfigurationManager:
         
         logger.info(f"Effective configuration saved to: {output_path}")
 
+    def print_startup_info(self) -> None:
+        """Print startup information similar to the legacy ConfigManager"""
+        print("\n" + "=" * 60)
+        print("🏯 YŌSAI INTEL DASHBOARD")
+        print("=" * 60)
+        print(f"🌐 URL: http://{self.app_config.host}:{self.app_config.port}")
+        print(f"🔧 Debug Mode: {self.app_config.debug}")
+        print(f"📊 Analytics: http://{self.app_config.host}:{self.app_config.port}/analytics")
+        print("=" * 60)
+        if self.app_config.debug:
+            print("⚠️  Running in DEBUG mode - do not use in production!")
+        print("\n🚀 Dashboard starting...")
+
 # Factory function for dependency injection
 def create_configuration_manager() -> ConfigurationManager:
     """Factory function to create and load configuration manager"""

--- a/core/app_factory.py
+++ b/core/app_factory.py
@@ -33,7 +33,7 @@ class YosaiDash(dash.Dash):
     def container(self) -> Container:
         """Get DI container"""
         if self._yosai_container is None:
-           self._yosai_container = get_configured_container()
+            self._yosai_container = get_configured_container_with_yaml()
         return self._yosai_container
     
     def get_service(self, name: str) -> Any:
@@ -69,7 +69,7 @@ class DashAppFactory:
             config_manager.load_configuration(config_path)
             
             # Get configured container with YAML config
-            container = get_configured_container()
+            container = get_configured_container_with_yaml()
             # Create Dash app with configuration
             app = YosaiDash(
                 __name__,
@@ -292,7 +292,7 @@ def verify_yaml_system():
         config_manager.load_configuration()
         
         # Test DI integration
-        container = get_configured_container()
+        container = get_configured_container_with_yaml()
         test_config = container.get('app_config')   
         # Test app creation
         app = create_application()


### PR DESCRIPTION
## Summary
- fix incorrect DI container function name in app factory
- add `print_startup_info` method to YAML ConfigurationManager

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_68516e434ea48320936a547ca8a1b244