### PR TITLE
Add startup info method to unified config manager

### DIFF
--- a/config/unified_config.py
+++ b/config/unified_config.py
@@ -333,6 +333,23 @@ class ConfigurationManager:
         print(f"Log Level: {self.config.app.log_level}")
         print("=" * 40)
 
+    def print_startup_info(self) -> None:
+        """Print startup information similar to yaml_config"""
+        if not self.config:
+            print("Configuration not loaded")
+            return
+
+        print("\n" + "=" * 60)
+        print("🏯 YŌSAI INTEL DASHBOARD")
+        print("=" * 60)
+        print(f"🌐 URL: http://{self.config.app.host}:{self.config.app.port}")
+        print(f"🔧 Debug Mode: {self.config.app.debug}")
+        print(f"📊 Analytics: http://{self.config.app.host}:{self.config.app.port}/analytics")
+        print("=" * 60)
+        if self.config.app.debug:
+            print("⚠️  Running in DEBUG mode - do not use in production!")
+        print("\n🚀 Dashboard starting...")
+
 # Global configuration manager
 config_manager = ConfigurationManager()
 


### PR DESCRIPTION
## Summary
- extend unified_config.ConfigurationManager with a `print_startup_info` helper

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas' and 'dash')*

------
https://chatgpt.com/codex/tasks/task_e_68516f847fe08320ab20062e728b19ab