### PR TITLE
Add title support in YAML config

### DIFF
--- a/config/yaml_config.py
+++ b/config/yaml_config.py
@@ -19,6 +19,7 @@ class AppConfig:
     debug: bool = False
     host: str = "127.0.0.1"
     port: int = 8050
+    title: str = "Yōsai Intel Dashboard"
     log_level: str = "INFO"
     app_name: str = "Yōsai Intel Dashboard"
     enable_profiling: bool = False
@@ -334,6 +335,7 @@ class ConfigurationManager:
                 'debug': self._environment == 'development',
                 'host': '127.0.0.1',
                 'port': 8050,
+                'title': 'Yōsai Intel Dashboard',
                 'log_level': 'DEBUG' if self._environment == 'development' else 'INFO',
                 'app_name': 'Yōsai Intel Dashboard'
             },

--- a/tests/test_yaml_config.py
+++ b/tests/test_yaml_config.py
@@ -1,0 +1,22 @@
+import os
+import tempfile
+import yaml
+from config.yaml_config import ConfigurationManager
+
+def test_app_title_loaded_from_yaml():
+    data = {
+        'app': {
+            'title': 'Custom Dashboard'
+        }
+    }
+    with tempfile.NamedTemporaryFile('w+', delete=False, suffix='.yaml') as tmp:
+        yaml.dump(data, tmp)
+        tmp_path = tmp.name
+    try:
+        manager = ConfigurationManager(config_path=tmp_path)
+        manager.load_configuration()
+        assert manager.app_config.title == 'Custom Dashboard'
+    finally:
+        os.remove(tmp_path)
+
+


### PR DESCRIPTION
## Summary
- include `title` in `AppConfig` dataclass
- default to `Yōsai Intel Dashboard`
- ensure default configuration includes a title
- test YAML loading of the new field

## Testing
- `black . --check` *(fails: many files would be reformatted)*
- `pytest -q` *(fails: missing dependencies like pandas, dash, yaml)*

------
https://chatgpt.com/codex/tasks/task_e_6851707a2bd883209cb70af5733bf040