### PR TITLE
Add .dockerignore

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,3 @@
+.git
+tests/
+*.pyc


### PR DESCRIPTION
## Summary
- add `.dockerignore` to prevent extra files from entering the Docker build context

## Testing
- `python tests/test_modular_system.py` *(fails: ModuleNotFoundError: pandas)*
- `pytest -q` *(fails: ModuleNotFoundError: pandas)*
- `mypy .` *(fails: unterminated string literal)*
- `black . --check` *(fails: files would be reformatted)*
- `flake8 .` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6851d9424134832090fe522e00988ea6