### PR TITLE
Fix host env var docs

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -4,7 +4,7 @@
 
 # Application Configuration
 DEBUG=true
-APP_HOST=127.0.0.1
+HOST=127.0.0.1
 PORT=8050
 LOG_LEVEL=INFO
 

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ yosai_intel_dashboard/
 4. **Set up environment:**
    ```bash
    cp .env.example .env
-   # Edit .env with your configuration
+   # Edit .env with your configuration (e.g. set HOST and database info)
    ```
 
 5. **Run the application:**

--- a/config/staging.yaml
+++ b/config/staging.yaml
@@ -14,7 +14,7 @@
 app:
   # Staging should be production-like but allow some debugging
   debug: ${DEBUG_MODE:false}
-  host: ${APP_HOST:0.0.0.0}
+  host: ${HOST:0.0.0.0}
   port: ${PORT:8050}
   title: "Yōsai Intel Dashboard - Staging"
   timezone: ${TIMEZONE:UTC}

--- a/core/config_manager.py
+++ b/core/config_manager.py
@@ -28,7 +28,7 @@ class ConfigManager:
         """Extract from your current get_app_config() function"""
         return AppConfig(
             debug=os.getenv('DEBUG', 'True').lower() == 'true',
-            host=os.getenv('HOST', '127.0.0.1'),
+            host=os.getenv('HOST') or os.getenv('APP_HOST', '127.0.0.1'),
             port=int(os.getenv('PORT', '8050')),
             secret_key=os.getenv('SECRET_KEY', 'dev-key-change-in-production')
         )


### PR DESCRIPTION
## Summary
- standardize on `HOST` environment variable
- clarify README instructions
- update staging config to use `HOST`
- allow legacy `APP_HOST` variable in the config manager

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*
- `black --check .` *(fails: would reformat many files)*
- `flake8` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6851d94ba75483209f4f20be3cdd027f