### PR TITLE
Fix analytics cache timing

### DIFF
--- a/services/analytics_service.py
+++ b/services/analytics_service.py
@@ -38,9 +38,12 @@ class AnalyticsService:
         current_time = datetime.now()
         
         # Check if cached and not expired
-        if (cache_key in self._cache and 
-            cache_key in self._cache_timestamps and
-            (current_time - self._cache_timestamps[cache_key]).seconds < self.config.cache_timeout_seconds):
+        if (
+            cache_key in self._cache
+            and cache_key in self._cache_timestamps
+            and (current_time - self._cache_timestamps[cache_key]).total_seconds()
+            < self.config.cache_timeout_seconds
+        ):
             return self._cache[cache_key]
         
         # Execute and cache

--- a/tests/test_cache_expiration.py
+++ b/tests/test_cache_expiration.py
@@ -1,0 +1,29 @@
+import time
+from services.analytics_service import AnalyticsService, AnalyticsConfig
+
+
+def test_cache_expiration():
+    config = AnalyticsConfig(cache_timeout_seconds=1)
+    service = AnalyticsService(config)
+
+    call_count = {"count": 0}
+
+    def func():
+        call_count["count"] += 1
+        return call_count["count"]
+
+    # First call caches the result
+    assert service._get_cached_or_execute("test", func) == 1
+    assert call_count["count"] == 1
+
+    # Second call within timeout uses cache
+    assert service._get_cached_or_execute("test", func) == 1
+    assert call_count["count"] == 1
+
+    # Wait for cache to expire
+    time.sleep(1.1)
+
+    # After expiration the function should run again
+    assert service._get_cached_or_execute("test", func) == 2
+    assert call_count["count"] == 2
+


### PR DESCRIPTION
## Summary
- use `total_seconds()` when checking cache age to ensure precision
- add unit test confirming cache expiry after timeout

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_6851de3009388320bcbd7a3f8cc3c66b