### PR TITLE
Read DB_PASSWORD from .env

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -10,11 +10,11 @@ LOG_LEVEL=INFO
 
 # Database Configuration
 DB_TYPE=mock
-DB_HOST=localhost
+DB_HOST=your_db_host
 DB_PORT=5432
-DB_NAME=yosai_intel
-DB_USER=postgres
-DB_PASSWORD=your_password_here
+DB_NAME=your_db_name
+DB_USER=your_db_user
+DB_PASSWORD=your_db_password
 
 # Cache Configuration
 CACHE_TYPE=memory

--- a/README.md
+++ b/README.md
@@ -93,6 +93,8 @@ Using Docker Compose:
 ```bash
 docker-compose up -d
 ```
+Docker Compose reads variables from a `.env` file in this directory. Set
+`DB_PASSWORD` there (or export it in your shell) before starting the services.
 
 ## 🧪 Testing
 
@@ -128,11 +130,11 @@ flake8 .
 Configure your database in `.env`:
 ```
 DB_TYPE=postgresql  # or 'sqlite' or 'mock'
-DB_HOST=localhost
+DB_HOST=your_db_host
 DB_PORT=5432
-DB_NAME=yosai_intel
-DB_USER=your_user
-DB_PASSWORD=your_password
+DB_NAME=your_db_name
+DB_USER=your_db_user
+DB_PASSWORD=your_db_password
 ```
 
 ### Application

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,6 +3,8 @@ version: '3.8'
 services:
   dashboard:
     build: .
+    env_file:
+      - .env
     ports:
       - "8050:8050"
     environment:
@@ -10,7 +12,7 @@ services:
       - DB_HOST=postgres
       - DB_NAME=yosai_intel
       - DB_USER=postgres
-      - DB_PASSWORD=password
+      - DB_PASSWORD=${DB_PASSWORD}
     depends_on:
       - postgres
     volumes:
@@ -22,7 +24,7 @@ services:
     environment:
       POSTGRES_DB: yosai_intel
       POSTGRES_USER: postgres
-      POSTGRES_PASSWORD: password
+      POSTGRES_PASSWORD: ${DB_PASSWORD}
     volumes:
       - postgres_data:/var/lib/postgresql/data
       - ./database_setup.sql:/docker-entrypoint-initdb.d/init.sql


### PR DESCRIPTION
## Summary
- support DB_PASSWORD from env file in `docker-compose.yml`
- document docker environment usage
- show placeholder database credentials in `.env.example`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*
- `mypy .` *(fails: unterminated string literal)*
- `black . --check` *(fails: many files would be reformatted)*
- `flake8 .` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6851de33e5d88320961adf3e44805e02