### PR TITLE
Refactor deep analytics helpers

### DIFF
--- a/tests/test_deep_analytics_helpers.py
+++ b/tests/test_deep_analytics_helpers.py
@@ -1,0 +1,16 @@
+import pandas as pd
+from pages import deep_analytics
+
+
+def test_validate_file_returns_types() -> None:
+    df = pd.DataFrame({'A': [1, 2]})
+    valid, alerts, suggestions = deep_analytics._validate_file(deep_analytics.FileProcessor, df, 'file.csv')
+    assert isinstance(valid, bool)
+    assert isinstance(alerts, list)
+    assert isinstance(suggestions, list)
+
+
+def test_generate_analytics_data_returns_dict() -> None:
+    df = pd.DataFrame({'A': [1, 2]})
+    analytics = deep_analytics._generate_analytics_data(None, df, 1)
+    assert isinstance(analytics, dict)


### PR DESCRIPTION
## Summary
- extract validation and analytics generation helpers
- use helpers inside deep analytics callback
- test return types of new helpers

## Testing
- `python -m py_compile pages/deep_analytics.py tests/test_deep_analytics_helpers.py`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_6851e23227ac8320811630a98524872d