### PR TITLE
Update CI workflow for translation checks

### DIFF
--- a/workflow/ci.yml
+++ b/workflow/ci.yml
@@ -28,6 +28,15 @@ jobs:
           pip install -r requirements.txt
           pip install black flake8 mypy bandit pytest pytest-cov safety
 
+      - name: 🌐 Extract translations
+        run: pybabel extract -F babel.cfg -o messages.pot .
+
+      - name: 🌐 Compile translations
+        run: pybabel compile -d translations
+
+      - name: 🔎 Check missing translations
+        run: python scripts/check_missing_translations.py
+
       # ----- Lint & static analysis -----
       - name: 🧹 Black (format check)
         run: black --check --diff .


### PR DESCRIPTION
## Summary
- add pybabel extract step
- compile translations and check for missing keys

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_6851f92933508320bc282c9f35e3da50