### PR TITLE
Fix env overrides causing secret errors

### DIFF
--- a/app.py
+++ b/app.py
@@ -67,7 +67,10 @@ def get_config_path() -> Optional[str]:
 
     # Check for explicit config file in environment
     manager = SecretManager()
-    config_file = manager.get("YOSAI_CONFIG_FILE", None)
+    try:
+        config_file = manager.get("YOSAI_CONFIG_FILE")
+    except KeyError:
+        config_file = None
     if config_file and Path(config_file).exists():
         print(f"📋 Using config file from YOSAI_CONFIG_FILE: {config_file}")
         return config_file

--- a/config/yaml_config.py
+++ b/config/yaml_config.py
@@ -136,7 +136,10 @@ class EnvironmentOverrideProcessor:
         # Process each environment variable
         manager = SecretManager()
         for env_var, config_path in env_mappings.items():
-            env_value = manager.get(env_var, None)
+            try:
+                env_value = manager.get(env_var)
+            except KeyError:
+                env_value = None
             if env_value is not None:
                 EnvironmentOverrideProcessor._set_nested_value(
                     config,


### PR DESCRIPTION
## Summary
- handle missing env vars in config overrides
- catch YOSAI_CONFIG_FILE when not defined

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'scripts')*
- `black --check app.py config/yaml_config.py`

------
https://chatgpt.com/codex/tasks/task_e_685201fc35f083209b388035cab82164