### PR TITLE
Document configuration variables

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -3,6 +3,8 @@
 # These variables override values in config/config.yaml
 
 # Application Configuration
+YOSAI_ENV=development
+# YOSAI_CONFIG_FILE=/absolute/path/to/custom.yaml
 DEBUG=true
 HOST=127.0.0.1
 PORT=8050

--- a/README.md
+++ b/README.md
@@ -176,6 +176,23 @@ python app.py
 These values override `database.host`, `database.username`, `cache.host` and
 `security.secret_key` from the loaded YAML.
 
+### Additional Environment Variables
+
+Two optional variables control which configuration file is loaded:
+
+- `YOSAI_ENV` – set to `development`, `staging`, `production` or `test` to
+  automatically load the matching file in `config/` (default: `development`).
+- `YOSAI_CONFIG_FILE` – absolute path to a custom YAML configuration file. When
+  set it takes precedence over `YOSAI_ENV`.
+
+Example:
+
+```bash
+YOSAI_ENV=production python app.py
+# or
+YOSAI_CONFIG_FILE=/path/to/custom.yaml python app.py
+```
+
 ## 📊 Modular Components
 
 ### Database Layer (`config/`)


### PR DESCRIPTION
## Summary
- explain optional environment variables YOSAI_ENV and YOSAI_CONFIG_FILE in README
- include YOSAI_ENV and YOSAI_CONFIG_FILE placeholders in `.env.example`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_68520407a144832083fd64c3f4b8ddea