### PR TITLE
Handle missing dash view

### DIFF
--- a/core/app_factory.py
+++ b/core/app_factory.py
@@ -112,9 +112,14 @@ class DashAppFactory:
             )
             CSRFProtect(server)
             init_auth(server)
-            server.view_functions["dash.index"] = login_required(
-                server.view_functions["dash.index"]
-            )
+            if "dash.index" in server.view_functions:
+                server.view_functions["dash.index"] = login_required(
+                    server.view_functions["dash.index"]
+                )
+            else:
+                logger.warning(
+                    "dash.index view function not found - skipping login_required wrapper"
+                )
 
             babel = Babel(server)
 


### PR DESCRIPTION
## Summary
- handle missing `dash.index` view

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_68521c1239cc8320a6fdc815d73699cf