### PR TITLE
Fix Babel locale selector compatibility

### DIFF
--- a/core/app_factory.py
+++ b/core/app_factory.py
@@ -123,9 +123,15 @@ class DashAppFactory:
 
             babel = Babel(server)
 
-            @babel.localeselector
             def get_locale():
                 return session.get("lang", "en")
+
+            if hasattr(babel, "localeselector"):
+                babel.localeselector(get_locale)
+            elif hasattr(babel, "locale_selector_func"):
+                babel.locale_selector_func = get_locale
+            else:
+                logger.warning("Babel does not support locale selection")
 
             @server.route("/i18n/<lang>")
             def set_lang(lang: str):


### PR DESCRIPTION
## Summary
- handle new `Babel` API for locale selection when Flask-Babel is installed

## Testing
- `pytest -q` *(fails: ModuleNotFoundError for flask, pandas etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68521e18d4d483208ef58b686ad7a7e6