### PR TITLE
Add plugin manager support

### DIFF
--- a/core/app_factory.py
+++ b/core/app_factory.py
@@ -16,6 +16,7 @@ from .layout_manager import LayoutManager
 from .callback_manager import CallbackManager
 from .service_registry import get_configured_container_with_yaml
 from .container import Container
+from .plugins.manager import PluginManager
 
 logger = logging.getLogger(__name__)
 
@@ -89,6 +90,11 @@ class DashAppFactory:
             app.title = config_manager.app_config.title
             app._config_manager = config_manager
             app._yosai_container = container
+
+            # Initialize and load plugins
+            plugin_manager = PluginManager(container, config_manager)
+            plugin_results = plugin_manager.load_all_plugins()
+            app._yosai_plugin_manager = plugin_manager
 
             # Initialize components
             component_registry = ComponentRegistry()
@@ -388,4 +394,5 @@ __all__ = [
     "DashAppFactory",
     "YosaiDash",
     "verify_yaml_system",
+    "PluginManager",
 ]

--- a/core/plugins/manager.py
+++ b/core/plugins/manager.py
@@ -1,0 +1,40 @@
+import importlib
+import pkgutil
+import logging
+from typing import List, Any
+
+from core.container import Container
+from config.yaml_config import ConfigurationManager
+
+logger = logging.getLogger(__name__)
+
+class PluginManager:
+    """Simple plugin manager that loads plugins from the 'plugins' package."""
+
+    def __init__(self, container: Container, config_manager: ConfigurationManager, package: str = "plugins"):
+        self.container = container
+        self.config_manager = config_manager
+        self.package = package
+        self.loaded_plugins: List[Any] = []
+
+    def load_all_plugins(self) -> List[Any]:
+        """Dynamically load all plugins from the configured package."""
+        try:
+            pkg = importlib.import_module(self.package)
+        except ModuleNotFoundError:
+            logger.info("Plugins package '%s' not found", self.package)
+            return []
+
+        results = []
+        for loader, name, is_pkg in pkgutil.iter_modules(pkg.__path__):
+            module_name = f"{self.package}.{name}"
+            try:
+                module = importlib.import_module(module_name)
+                if hasattr(module, "init_plugin"):
+                    result = module.init_plugin(self.container, self.config_manager)
+                    results.append(result)
+                self.loaded_plugins.append(module)
+                logger.info("Loaded plugin %s", module_name)
+            except Exception as exc:
+                logger.error("Failed to load plugin %s: %s", module_name, exc)
+        return results


### PR DESCRIPTION
## Summary
- add plugin manager module with dynamic loader
- integrate `PluginManager` into app factory

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_6852434997e48320b3b7313913f8ce2e