### PR TITLE
Fix app factory syntax

### DIFF
--- a/core/app_factory.py
+++ b/core/app_factory.py
@@ -77,6 +77,7 @@ class DashAppFactory:
 
             # Get configured container with YAML config
             container = get_configured_container_with_yaml()
+
             # Create Dash app with configuration
             app = YosaiDash(
                 __name__,
@@ -94,7 +95,8 @@ class DashAppFactory:
             component_registry = ComponentRegistry()
             layout_manager = LayoutManager(component_registry)
             callback_manager = CallbackManager(
-                app, component_registry, layout_manager, container,
+                app, component_registry, layout_manager, container
+            )
 
             # Set layout
             app.layout = layout_manager.create_main_layout()
@@ -111,21 +113,7 @@ class DashAppFactory:
             )
             CSRFProtect(server)
             init_auth(server)
-            # Safely wrap dash.index with login_required
-            if "dash.index" in server.view_functions:
-            # Safely wrap dash.index with login_required
-            try:
-                if "dash.index" in server.view_functions:
-                    server.view_functions["dash.index"] = login_required(
-                        server.view_functions["dash.index"]
-                    )
-                else:
-                    logger.warning("dash.index view function not found")
-            except Exception as e:
-                logger.warning(f"Could not wrap dash.index with login_required: {e}")
-                logger.warning("dash.index view function not found - skipping login_required wrapper")
-                # Safely wrap dash.index with login_required
-                if "dash.index" in server.view_functions:
+
             # Safely wrap dash.index with login_required
             try:
                 if "dash.index" in server.view_functions:
@@ -136,8 +124,6 @@ class DashAppFactory:
                     logger.warning("dash.index view function not found")
             except Exception as e:
                 logger.warning(f"Could not wrap dash.index with login_required: {e}")
-                    logger.warning("dash.index view function not found - skipping login_required wrapper")
-            )
 
             babel = Babel(server)
 
@@ -152,6 +138,7 @@ class DashAppFactory:
 
             logger.info(
                 "Dashboard application created successfully with YAML configuration"
+            )
             return app
 
         except ImportError:
@@ -199,12 +186,14 @@ def create_application(config_path: Optional[str] = None) -> Optional[YosaiDash]
 
         logger.info(
             "Dashboard application created successfully with YAML configuration"
+        )
         return app
 
     except ImportError:
         logger.error("Cannot create application - Dash dependencies not available")
         print(
             "❌ Error: Dash not installed. Run: pip install dash dash-bootstrap-components"
+        )
         return None
     except Exception as e:
         logger.error(f"Error creating application: {e}")


### PR DESCRIPTION
## Summary
- repair create_app implementation
- fix closing parentheses in create_application

## Testing
- `black --check core/app_factory.py`
- `flake8 core/app_factory.py` *(fails: command not found)*
- `mypy core/app_factory.py` *(fails: missing dependencies)*
- `pytest` *(fails: ModuleNotFoundError)*

------
https://chatgpt.com/codex/tasks/task_e_68524829003483208122fd760ca7b313