### PR TITLE
Fix Babel locale selector

### DIFF
--- a/README.md
+++ b/README.md
@@ -234,6 +234,7 @@ implementation details.
 ## 🌐 Language Toggle
 
 Internationalization is built in with Flask-Babel. Click the language dropdown in the navigation bar to switch between English and Japanese. No additional environment variables are required.
+If you encounter an error like `"Babel" object has no attribute "localeselector"` when starting the app, ensure that the `Flask-Babel` package is installed and up to date (version 4 or later). The application now falls back to the new `locale_selector_func` API when needed.
 
 ![Language Toggle Demo](docs/i18n_demo.gif)
 

--- a/core/app_factory.py
+++ b/core/app_factory.py
@@ -127,9 +127,18 @@ class DashAppFactory:
 
             babel = Babel(server)
 
-            @babel.localeselector
-            def get_locale():
+            def _select_locale() -> str:
+                """Return preferred locale stored in the session"""
                 return session.get("lang", "en")
+
+            if hasattr(babel, "localeselector"):
+                # Flask-Babel < 4.x uses decorator based registration
+                @babel.localeselector
+                def get_locale() -> str:  # pragma: no cover - wrapper for older API
+                    return _select_locale()
+            else:
+                # Flask-Babel >= 4.x expects locale_selector_func attribute
+                babel.locale_selector_func = _select_locale
 
             @server.route("/i18n/<lang>")
             def set_lang(lang: str):


### PR DESCRIPTION
## Summary
- fix locale selector registration for Flask-Babel 4+
- document Babel compatibility in README

## Testing
- `python tests/test_modular_system.py` *(fails: ModuleNotFoundError: No module named 'pandas')*
- `python tests/test_dashboard.py` *(fails: ModuleNotFoundError: No module named 'pandas')*
- `pytest` *(fails to collect tests: ModuleNotFoundError: No module named 'scripts')*

------
https://chatgpt.com/codex/tasks/task_e_68524a73bc248320bb392a1e25a3ffdc