### PR TITLE
Add Dash CSRF protection plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,6 +125,7 @@ flake8 .
 - **Modular Architecture**: Easy to maintain, test, and extend
 - **Multi-page Interface**: Organized functionality across multiple pages
 - **Type-Safe**: Full type annotations and validation
+- **CSRF Protection Plugin**: Optional production-ready CSRF middleware for Dash
 
 ## 🔧 Configuration
 

--- a/dash_csrf_plugin/__init__.py
+++ b/dash_csrf_plugin/__init__.py
@@ -1,0 +1,35 @@
+from .plugin import DashCSRFPlugin
+from .config import (
+    CSRFConfig,
+    CSRFMode,
+    create_development_config,
+    create_production_config,
+    create_testing_config,
+    auto_detect_config,
+)
+from .manager import CSRFManager
+from .exceptions import (
+    CSRFError,
+    CSRFConfigurationError,
+    CSRFValidationError,
+    CSRFTokenError,
+    CSRFModeError,
+)
+from .utils import CSRFUtils
+
+__all__ = [
+    "DashCSRFPlugin",
+    "CSRFConfig",
+    "CSRFMode",
+    "create_development_config",
+    "create_production_config",
+    "create_testing_config",
+    "auto_detect_config",
+    "CSRFManager",
+    "CSRFError",
+    "CSRFConfigurationError",
+    "CSRFValidationError",
+    "CSRFTokenError",
+    "CSRFModeError",
+    "CSRFUtils",
+]

--- a/dash_csrf_plugin/cli.py
+++ b/dash_csrf_plugin/cli.py
@@ -1,0 +1,178 @@
+"""
+Command-line interface for CSRF plugin
+"""
+
+import click
+import sys
+import json
+from typing import Dict, Any
+
+from .plugin import DashCSRFPlugin
+from .config import CSRFConfig, CSRFMode
+from .utils import CSRFUtils
+
+
+@click.group()
+@click.version_option()
+def cli():
+    """Dash CSRF Protection Plugin CLI"""
+    pass
+
+
+@cli.command()
+@click.option('--config-file', '-c', help='Path to configuration file')
+@click.option('--secret-key', '-s', help='Secret key to validate')
+@click.option('--mode', '-m', 
+              type=click.Choice(['development', 'production', 'testing', 'enabled', 'disabled']),
+              default='auto',
+              help='CSRF mode to check')
+@click.option('--verbose', '-v', is_flag=True, help='Verbose output')
+def check_csrf(config_file, secret_key, mode, verbose):
+    """Check CSRF configuration and security"""
+    click.echo("🛡️  Dash CSRF Protection Plugin - Security Check")
+    click.echo("=" * 50)
+    
+    try:
+        # Load configuration
+        if config_file:
+            config = CSRFConfig.from_dict(json.load(open(config_file)))
+        else:
+            config = CSRFConfig()
+        
+        if secret_key:
+            config.secret_key = secret_key
+        
+        # Validate configuration
+        issues = CSRFUtils.validate_config_security(config.to_dict())
+        
+        # Display results
+        click.echo(f"Configuration Mode: {mode}")
+        click.echo(f"CSRF Enabled: {config.enabled}")
+        click.echo(f"Secret Key Set: {'Yes' if config.secret_key else 'No'}")
+        click.echo(f"SSL Strict: {config.ssl_strict}")
+        click.echo(f"Time Limit: {config.time_limit} seconds")
+        click.echo()
+        
+        # Security issues
+        if issues['errors']:
+            click.echo("❌ Critical Issues:")
+            for error in issues['errors']:
+                click.echo(f"  • {error}", err=True)
+            click.echo()
+        
+        if issues['warnings']:
+            click.echo("⚠️  Warnings:")
+            for warning in issues['warnings']:
+                click.echo(f"  • {warning}")
+            click.echo()
+        
+        if issues['recommendations']:
+            click.echo("💡 Recommendations:")
+            for rec in issues['recommendations']:
+                click.echo(f"  • {rec}")
+            click.echo()
+        
+        # Overall status
+        if not issues['errors']:
+            click.echo("✅ CSRF configuration looks good!")
+            sys.exit(0)
+        else:
+            click.echo("❌ CSRF configuration has issues that need attention")
+            sys.exit(1)
+            
+    except Exception as e:
+        click.echo(f"❌ Error checking CSRF configuration: {e}", err=True)
+        sys.exit(1)
+
+
+@cli.command()
+@click.option('--length', '-l', default=32, help='Secret key length')
+def generate_key(length):
+    """Generate a secure secret key"""
+    key = CSRFUtils.generate_secret_key(length)
+    click.echo("🔑 Generated Secret Key:")
+    click.echo(key)
+    click.echo()
+    click.echo("💡 Store this key securely and set it as your SECRET_KEY environment variable:")
+    click.echo(f"export SECRET_KEY='{key}'")
+
+
+@cli.command()
+@click.argument('app_module')
+@click.option('--host', '-h', default='127.0.0.1', help='Host to bind to')
+@click.option('--port', '-p', default=8050, help='Port to bind to')
+@click.option('--debug', is_flag=True, help='Enable debug mode')
+def run(app_module, host, port, debug):
+    """Run a Dash app with CSRF protection"""
+    try:
+        # Import the app module
+        import importlib
+        module = importlib.import_module(app_module)
+        
+        if hasattr(module, 'app'):
+            app = module.app
+        elif hasattr(module, 'application'):
+            app = module.application
+        else:
+            click.echo("❌ Could not find 'app' or 'application' in module", err=True)
+            sys.exit(1)
+        
+        # Check if CSRF plugin is configured
+        if hasattr(app, '_plugins') and 'csrf' in app._plugins:
+            csrf_plugin = app._plugins['csrf']
+            click.echo(f"✅ CSRF Plugin detected (Mode: {csrf_plugin.mode.value})")
+        else:
+            click.echo("⚠️  No CSRF plugin detected in app")
+        
+        # Run the app
+        click.echo(f"🚀 Starting Dash app on {host}:{port}")
+        app.run_server(host=host, port=port, debug=debug)
+        
+    except ImportError as e:
+        click.echo(f"❌ Could not import module '{app_module}': {e}", err=True)
+        sys.exit(1)
+    except Exception as e:
+        click.echo(f"❌ Error running app: {e}", err=True)
+        sys.exit(1)
+
+
+@cli.command()
+@click.argument('output_file')
+@click.option('--mode', '-m', 
+              type=click.Choice(['development', 'production', 'testing']),
+              default='development',
+              help='Configuration mode')
+@click.option('--secret-key', '-s', help='Secret key (generated if not provided)')
+def init_config(output_file, mode, secret_key):
+    """Initialize a CSRF configuration file"""
+    try:
+        # Generate secret key if not provided
+        if not secret_key:
+            secret_key = CSRFUtils.generate_secret_key()
+        
+        # Create configuration based on mode
+        if mode == 'development':
+            config = CSRFConfig.for_development(secret_key=secret_key)
+        elif mode == 'production':
+            config = CSRFConfig.for_production(secret_key)
+        elif mode == 'testing':
+            config = CSRFConfig.for_testing(secret_key=secret_key)
+        
+        # Write configuration file
+        config_dict = config.to_dict()
+        config_dict['secret_key'] = secret_key  # Include actual secret key
+        
+        with open(output_file, 'w') as f:
+            json.dump(config_dict, f, indent=2)
+        
+        click.echo(f"✅ Configuration file created: {output_file}")
+        click.echo(f"📋 Mode: {mode}")
+        click.echo(f"🔐 Secret key included in file - keep it secure!")
+        
+    except Exception as e:
+        click.echo(f"❌ Error creating configuration: {e}", err=True)
+        sys.exit(1)
+
+
+if __name__ == '__main__':
+    cli()

--- a/dash_csrf_plugin/config.py
+++ b/dash_csrf_plugin/config.py
@@ -1,0 +1,225 @@
+"""
+Configuration classes and enums for CSRF protection plugin
+"""
+
+import os
+from enum import Enum
+from typing import List, Optional, Dict, Any, Callable
+from dataclasses import dataclass, field
+
+
+class CSRFMode(Enum):
+    """CSRF protection modes"""
+    AUTO = "auto"           # Automatically detect appropriate mode
+    ENABLED = "enabled"     # CSRF protection enabled
+    DISABLED = "disabled"   # CSRF protection disabled
+    DEVELOPMENT = "development"  # Development mode (CSRF disabled with warnings)
+    PRODUCTION = "production"    # Production mode (CSRF enabled with strict settings)
+    TESTING = "testing"     # Testing mode (CSRF disabled, testing flags set)
+
+
+@dataclass
+class CSRFConfig:
+    """
+    Configuration class for CSRF protection
+    
+    Provides comprehensive configuration options for CSRF protection
+    with sensible defaults for different environments.
+    """
+    
+    # Core settings
+    enabled: bool = True
+    secret_key: Optional[str] = None
+    
+    # Timing and security
+    time_limit: int = 3600  # 1 hour in seconds
+    ssl_strict: bool = True
+    check_referer: bool = True
+    
+    # HTTP methods to protect
+    methods: List[str] = field(default_factory=lambda: ['POST', 'PUT', 'PATCH', 'DELETE'])
+    
+    # Route exemptions
+    exempt_routes: List[str] = field(default_factory=list)
+    exempt_views: List[str] = field(default_factory=list)
+    
+    # Error handling
+    custom_error_handler: Optional[Callable] = None
+    error_template_path: Optional[str] = None
+    
+    # Advanced settings
+    field_name: str = 'csrf_token'
+    header_name: str = 'X-CSRFToken'
+    hash_algorithm: str = 'sha1'
+    
+    # Plugin behavior
+    auto_exempt_dash_routes: bool = True
+    validate_on_callback: bool = True
+    include_meta_tag: bool = True
+    
+    def __post_init__(self):
+        """Post-initialization validation and setup"""
+        # Set secret key from environment if not provided
+        if not self.secret_key:
+            self.secret_key = os.getenv('SECRET_KEY') or os.getenv('FLASK_SECRET_KEY')
+        
+        # Validate configuration
+        self._validate()
+    
+    def _validate(self) -> None:
+        """Validate configuration settings"""
+        if self.enabled and not self.secret_key:
+            raise ValueError("SECRET_KEY is required when CSRF protection is enabled")
+        
+        if self.time_limit <= 0:
+            raise ValueError("time_limit must be positive")
+        
+        if not self.methods:
+            raise ValueError("At least one HTTP method must be protected")
+    
+    @classmethod
+    def for_development(cls, **kwargs) -> 'CSRFConfig':
+        """Create development configuration"""
+        defaults = {
+            'enabled': False,
+            'ssl_strict': False,
+            'check_referer': False,
+            'secret_key': 'dev-secret-key-change-in-production'
+        }
+        defaults.update(kwargs)
+        return cls(**defaults)
+    
+    @classmethod
+    def for_production(cls, secret_key: str, **kwargs) -> 'CSRFConfig':
+        """Create production configuration"""
+        defaults = {
+            'enabled': True,
+            'secret_key': secret_key,
+            'ssl_strict': True,
+            'check_referer': True,
+            'time_limit': 3600
+        }
+        defaults.update(kwargs)
+        return cls(**defaults)
+    
+    @classmethod
+    def for_testing(cls, **kwargs) -> 'CSRFConfig':
+        """Create testing configuration"""
+        defaults = {
+            'enabled': False,
+            'ssl_strict': False,
+            'check_referer': False,
+            'secret_key': 'test-secret-key'
+        }
+        defaults.update(kwargs)
+        return cls(**defaults)
+    
+    @classmethod
+    def from_environment(cls, prefix: str = 'CSRF_') -> 'CSRFConfig':
+        """Create configuration from environment variables"""
+        env_config = {}
+        
+        # Map environment variables to config attributes
+        env_mapping = {
+            f'{prefix}ENABLED': ('enabled', lambda x: x.lower() in ('true', '1', 'yes')),
+            f'{prefix}SECRET_KEY': ('secret_key', str),
+            f'{prefix}TIME_LIMIT': ('time_limit', int),
+            f'{prefix}SSL_STRICT': ('ssl_strict', lambda x: x.lower() in ('true', '1', 'yes')),
+            f'{prefix}CHECK_REFERER': ('check_referer', lambda x: x.lower() in ('true', '1', 'yes')),
+            f'{prefix}METHODS': ('methods', lambda x: x.split(',')),
+        }
+        
+        for env_var, (attr_name, converter) in env_mapping.items():
+            value = os.getenv(env_var)
+            if value is not None:
+                try:
+                    env_config[attr_name] = converter(value)
+                except (ValueError, TypeError) as e:
+                    raise ValueError(f"Invalid value for {env_var}: {value}") from e
+        
+        return cls(**env_config)
+    
+    @classmethod
+    def from_dict(cls, config_dict: Dict[str, Any]) -> 'CSRFConfig':
+        """Create configuration from dictionary"""
+        # Filter out unknown keys
+        valid_keys = {field.name for field in cls.__dataclass_fields__.values()}
+        filtered_config = {k: v for k, v in config_dict.items() if k in valid_keys}
+        return cls(**filtered_config)
+    
+    def to_dict(self) -> Dict[str, Any]:
+        """Convert configuration to dictionary"""
+        return {
+            'enabled': self.enabled,
+            'secret_key': '***' if self.secret_key else None,  # Mask secret key
+            'time_limit': self.time_limit,
+            'ssl_strict': self.ssl_strict,
+            'check_referer': self.check_referer,
+            'methods': self.methods,
+            'exempt_routes': self.exempt_routes,
+            'exempt_views': self.exempt_views,
+            'field_name': self.field_name,
+            'header_name': self.header_name,
+            'hash_algorithm': self.hash_algorithm,
+            'auto_exempt_dash_routes': self.auto_exempt_dash_routes,
+            'validate_on_callback': self.validate_on_callback,
+            'include_meta_tag': self.include_meta_tag
+        }
+    
+    def update(self, **kwargs) -> 'CSRFConfig':
+        """Create new configuration with updated values"""
+        current_dict = self.to_dict()
+        current_dict.update(kwargs)
+        return self.from_dict(current_dict)
+    
+    def add_exempt_route(self, route: str) -> None:
+        """Add route to exemption list"""
+        if route not in self.exempt_routes:
+            self.exempt_routes.append(route)
+    
+    def add_exempt_view(self, view: str) -> None:
+        """Add view to exemption list"""
+        if view not in self.exempt_views:
+            self.exempt_views.append(view)
+    
+    def remove_exempt_route(self, route: str) -> None:
+        """Remove route from exemption list"""
+        if route in self.exempt_routes:
+            self.exempt_routes.remove(route)
+    
+    def remove_exempt_view(self, view: str) -> None:
+        """Remove view from exemption list"""
+        if view in self.exempt_views:
+            self.exempt_views.remove(view)
+
+
+# Factory functions for common configurations
+
+def create_development_config(**kwargs) -> CSRFConfig:
+    """Create development configuration with CSRF disabled"""
+    return CSRFConfig.for_development(**kwargs)
+
+
+def create_production_config(secret_key: str, **kwargs) -> CSRFConfig:
+    """Create production configuration with CSRF enabled"""
+    return CSRFConfig.for_production(secret_key, **kwargs)
+
+
+def create_testing_config(**kwargs) -> CSRFConfig:
+    """Create testing configuration"""
+    return CSRFConfig.for_testing(**kwargs)
+
+
+def auto_detect_config(app: dash.Dash, **kwargs) -> CSRFConfig:
+    """Auto-detect appropriate configuration based on app settings"""
+    app_type = CSRFUtils.detect_dash_app_type(app)
+    
+    if app_type == 'development':
+        return create_development_config(**kwargs)
+    elif app_type == 'testing':
+        return create_testing_config(**kwargs)
+    else:
+        secret_key = kwargs.get('secret_key') or app.server.config.get('SECRET_KEY')
+        if not secret_key:
+            raise ValueError("SECRET_KEY required for production configuration")
+        return create_production_config(secret_key, **kwargs)

--- a/dash_csrf_plugin/exceptions.py
+++ b/dash_csrf_plugin/exceptions.py
@@ -1,0 +1,28 @@
+"""
+Custom exceptions for CSRF protection plugin
+"""
+
+
+class CSRFError(Exception):
+    """Base exception for CSRF-related errors"""
+    pass
+
+
+class CSRFConfigurationError(CSRFError):
+    """Raised when there's a configuration error"""
+    pass
+
+
+class CSRFValidationError(CSRFError):
+    """Raised when CSRF token validation fails"""
+    pass
+
+
+class CSRFTokenError(CSRFError):
+    """Raised when there's an issue with CSRF token generation or parsing"""
+    pass
+
+
+class CSRFModeError(CSRFError):
+    """Raised when there's an invalid CSRF mode"""
+    pass

--- a/dash_csrf_plugin/manager.py
+++ b/dash_csrf_plugin/manager.py
@@ -1,0 +1,409 @@
+"""
+CSRF Manager for handling CSRF protection in Dash applications
+"""
+
+import logging
+from typing import Optional, List, Dict, Any
+from flask import request, session, current_app
+from flask_wtf.csrf import CSRFProtect, generate_csrf, validate_csrf
+from werkzeug.exceptions import BadRequest
+import dash
+from dash import html, dcc
+
+from .config import CSRFConfig, CSRFMode
+from .exceptions import CSRFError, CSRFValidationError
+from .utils import CSRFUtils
+
+logger = logging.getLogger(__name__)
+
+
+class CSRFManager:
+    """
+    Manages CSRF protection for Dash applications
+    
+    Handles:
+    - CSRF token generation and validation
+    - Route exemptions for Dash-specific endpoints
+    - Error handling and recovery
+    - Mode-specific behavior
+    """
+    
+    def __init__(self, 
+                 app: dash.Dash,
+                 config: CSRFConfig,
+                 mode: CSRFMode):
+        """
+        Initialize CSRF manager
+        
+        Args:
+            app: Dash application instance
+            config: CSRF configuration
+            mode: Protection mode
+        """
+        self.app = app
+        self.config = config
+        self.mode = mode
+        self.csrf_protect: Optional[CSRFProtect] = None
+        self.utils = CSRFUtils()
+        self._enabled = True
+        self._exempt_routes: List[str] = []
+        self._exempt_views: List[str] = []
+        self._initialized = False
+        
+    def init_app(self) -> None:
+        """Initialize CSRF protection for the application"""
+        if self._initialized:
+            return
+        
+        server = self.app.server
+        
+        # Apply configuration to Flask server
+        self._apply_config_to_server()
+        
+        # Initialize CSRF protection based on mode
+        if self.mode in [CSRFMode.ENABLED, CSRFMode.PRODUCTION]:
+            self._init_csrf_protection()
+        elif self.mode == CSRFMode.DEVELOPMENT:
+            self._init_development_mode()
+        elif self.mode == CSRFMode.TESTING:
+            self._init_testing_mode()
+        elif self.mode == CSRFMode.DISABLED:
+            self._init_disabled_mode()
+        
+        # Set up exempt routes
+        self._setup_default_exemptions()
+        
+        # Set up error handlers
+        self._setup_error_handlers()
+        
+        self._initialized = True
+        logger.info(f"CSRF Manager initialized in {self.mode.value} mode")
+    
+    def _apply_config_to_server(self) -> None:
+        """Apply CSRF configuration to Flask server"""
+        server = self.app.server
+        
+        config_mapping = {
+            'SECRET_KEY': self.config.secret_key,
+            'WTF_CSRF_TIME_LIMIT': self.config.time_limit,
+            'WTF_CSRF_SSL_STRICT': self.config.ssl_strict,
+            'WTF_CSRF_METHODS': self.config.methods,
+            'WTF_CSRF_CHECK_DEFAULT': self.config.check_referer,
+            'WTF_CSRF_ENABLED': self._should_enable_csrf()
+        }
+        
+        for key, value in config_mapping.items():
+            if value is not None:
+                server.config[key] = value
+    
+    def _should_enable_csrf(self) -> bool:
+        """Determine if CSRF should be enabled based on mode and config"""
+        if not self.config.enabled:
+            return False
+        
+        return self.mode in [CSRFMode.ENABLED, CSRFMode.PRODUCTION]
+    
+    def _init_csrf_protection(self) -> None:
+        """Initialize full CSRF protection"""
+        server = self.app.server
+        self.csrf_protect = CSRFProtect()
+        self.csrf_protect.init_app(server)
+        logger.info("CSRF protection enabled")
+    
+    def _init_development_mode(self) -> None:
+        """Initialize development mode (CSRF disabled with warnings)"""
+        server = self.app.server
+        server.config['WTF_CSRF_ENABLED'] = False
+        logger.warning("CSRF protection disabled for development mode")
+    
+    def _init_testing_mode(self) -> None:
+        """Initialize testing mode"""
+        server = self.app.server
+        server.config.update({
+            'WTF_CSRF_ENABLED': False,
+            'TESTING': True
+        })
+        logger.info("CSRF protection disabled for testing mode")
+    
+    def _init_disabled_mode(self) -> None:
+        """Initialize disabled mode"""
+        server = self.app.server
+        server.config['WTF_CSRF_ENABLED'] = False
+        logger.info("CSRF protection explicitly disabled")
+    
+    def _setup_default_exemptions(self) -> None:
+        """Set up default route exemptions for Dash"""
+        default_exempt_routes = [
+            '/_dash-dependencies',
+            '/_dash-layout',
+            '/_dash-component-suites',
+            '/_dash-update-component',
+            '/_favicon.ico',
+            '/_reload-hash',
+            '/assets/*',
+            '/health',
+            '/healthz'
+        ]
+        
+        for route in default_exempt_routes:
+            self.add_exempt_route(route)
+        
+        # Add custom exempt routes from config
+        for route in self.config.exempt_routes:
+            self.add_exempt_route(route)
+    
+    def _setup_error_handlers(self) -> None:
+        """Set up CSRF error handlers"""
+        server = self.app.server
+        
+        @server.errorhandler(400)
+        def handle_bad_request(error):
+            """Handle CSRF-related bad requests"""
+            if self._is_csrf_error(error):
+                return self._create_csrf_error_response(error)
+            return error
+        
+        @server.errorhandler(CSRFError)
+        def handle_csrf_error(error):
+            """Handle custom CSRF errors"""
+            return self._create_csrf_error_response(error)
+    
+    def _is_csrf_error(self, error) -> bool:
+        """Check if an error is CSRF-related"""
+        error_str = str(error)
+        csrf_indicators = ['CSRF', 'csrf', 'token', 'Cross-Site Request Forgery']
+        return any(indicator in error_str for indicator in csrf_indicators)
+    
+    def _create_csrf_error_response(self, error) -> tuple:
+        """Create user-friendly CSRF error response"""
+        if self.config.custom_error_handler:
+            return self.config.custom_error_handler(error)
+        
+        error_html = self._get_default_error_template()
+        return error_html, 400, {'Content-Type': 'text/html'}
+    
+    def _get_default_error_template(self) -> str:
+        """Get default CSRF error template"""
+        return """
+        <!DOCTYPE html>
+        <html lang="en">
+        <head>
+            <meta charset="UTF-8">
+            <meta name="viewport" content="width=device-width, initial-scale=1.0">
+            <title>Security Error</title>
+            <style>
+                body {
+                    font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+                    margin: 0;
+                    padding: 40px;
+                    background: #f8f9fa;
+                    color: #343a40;
+                }
+                .error-container {
+                    max-width: 600px;
+                    margin: 0 auto;
+                    background: white;
+                    padding: 40px;
+                    border-radius: 8px;
+                    box-shadow: 0 2px 10px rgba(0,0,0,0.1);
+                }
+                .error-icon {
+                    font-size: 48px;
+                    color: #dc3545;
+                    text-align: center;
+                    margin-bottom: 20px;
+                }
+                h1 {
+                    color: #dc3545;
+                    text-align: center;
+                    margin-bottom: 20px;
+                }
+                .error-message {
+                    background: #f8d7da;
+                    border: 1px solid #f5c6cb;
+                    color: #721c24;
+                    padding: 15px;
+                    border-radius: 5px;
+                    margin: 20px 0;
+                }
+                .action-buttons {
+                    text-align: center;
+                    margin-top: 30px;
+                }
+                .btn {
+                    background: #007bff;
+                    color: white;
+                    padding: 10px 20px;
+                    text-decoration: none;
+                    border-radius: 5px;
+                    margin: 0 10px;
+                    display: inline-block;
+                }
+                .btn:hover {
+                    background: #0056b3;
+                }
+            </style>
+        </head>
+        <body>
+            <div class="error-container">
+                <div class="error-icon">🛡️</div>
+                <h1>Security Token Error</h1>
+                <div class="error-message">
+                    <strong>Security Protection Activated</strong><br>
+                    Your session has expired or there was a security token mismatch. 
+                    This is a protective measure to keep your data safe.
+                </div>
+                <p>This can happen when:</p>
+                <ul>
+                    <li>Your session has been inactive for too long</li>
+                    <li>You opened the app in multiple browser tabs</li>
+                    <li>There was a network connectivity issue</li>
+                </ul>
+                <div class="action-buttons">
+                    <a href="/" class="btn">Reload Application</a>
+                    <a href="/login" class="btn">Sign In Again</a>
+                </div>
+            </div>
+        </body>
+        </html>
+        """
+    
+    def add_exempt_route(self, route: str) -> None:
+        """Add a route to CSRF exemption list"""
+        if route not in self._exempt_routes:
+            self._exempt_routes.append(route)
+            
+            if self.csrf_protect:
+                # Try to exempt the route from CSRF checking
+                try:
+                    self.csrf_protect.exempt(route)
+                except Exception as e:
+                    logger.warning(f"Could not exempt route {route}: {e}")
+    
+    def add_exempt_view(self, view_function: str) -> None:
+        """Add a view function to CSRF exemption list"""
+        if view_function not in self._exempt_views:
+            self._exempt_views.append(view_function)
+    
+    def get_csrf_token(self) -> str:
+        """Get current CSRF token"""
+        if not self._should_enable_csrf():
+            return ""
+        
+        try:
+            return generate_csrf()
+        except RuntimeError as e:
+            logger.warning(f"Could not generate CSRF token: {e}")
+            return ""
+    
+    def validate_csrf(self) -> bool:
+        """Validate CSRF token for current request"""
+        if not self._should_enable_csrf():
+            return True
+        
+        try:
+            # Try to get token from headers first, then form data
+            token = (request.headers.get('X-CSRFToken') or 
+                    request.headers.get('X-CSRF-Token') or
+                    request.form.get('csrf_token'))
+            
+            if token:
+                validate_csrf(token)
+                return True
+            else:
+                logger.warning("No CSRF token found in request")
+                return False
+                
+        except Exception as e:
+            logger.warning(f"CSRF validation failed: {e}")
+            return False
+    
+    def create_csrf_component(self, component_id: str = "csrf-token"):
+        """Create CSRF component for Dash layout"""
+        if not self._should_enable_csrf():
+            return html.Div(style={'display': 'none'})
+        
+        token = self.get_csrf_token()
+        
+        return html.Div([
+            # Store token in a hidden component
+            dcc.Store(id=component_id, data={'csrf_token': token}),
+            # Also add as meta tag for JavaScript access
+            html.Meta(name="csrf-token", content=token)
+        ], style={'display': 'none'})
+    
+    def disable(self) -> None:
+        """Temporarily disable CSRF protection"""
+        self._enabled = False
+        if self.app.server:
+            self.app.server.config['WTF_CSRF_ENABLED'] = False
+        logger.info("CSRF protection temporarily disabled")
+    
+    def enable(self) -> None:
+        """Re-enable CSRF protection"""
+        self._enabled = True
+        if self._should_enable_csrf() and self.app.server:
+            self.app.server.config['WTF_CSRF_ENABLED'] = True
+        logger.info("CSRF protection re-enabled")
+    
+    def update_config(self, config: CSRFConfig) -> None:
+        """Update CSRF configuration"""
+        self.config = config
+        self._apply_config_to_server()
+        logger.info("CSRF configuration updated")
+    
+    def get_status(self) -> Dict[str, Any]:
+        """Get current status of CSRF protection"""
+        return {
+            'enabled': self.is_enabled,
+            'mode': self.mode.value,
+            'csrf_protect_initialized': self.csrf_protect is not None,
+            'exempt_routes': self._exempt_routes,
+            'exempt_views': self._exempt_views,
+            'config_enabled': self.config.enabled,
+            'server_csrf_enabled': self.app.server.config.get('WTF_CSRF_ENABLED', False)
+        }
+    
+    @property
+    def is_enabled(self) -> bool:
+        """Check if CSRF protection is currently enabled"""
+        return (self._enabled and 
+                self.config.enabled and 
+                self.mode in [CSRFMode.ENABLED, CSRFMode.PRODUCTION])
+    
+    def health_check(self) -> Dict[str, Any]:
+        """Perform health check on CSRF system"""
+        status = {
+            'healthy': True,
+            'issues': [],
+            'recommendations': []
+        }
+        
+        # Check if secret key is set
+        if not self.app.server.config.get('SECRET_KEY'):
+            status['healthy'] = False
+            status['issues'].append('No SECRET_KEY configured')
+        
+        # Check if secret key is secure
+        secret_key = self.app.server.config.get('SECRET_KEY', '')
+        if secret_key in ['dev', 'development', 'test', 'secret']:
+            status['issues'].append('Insecure SECRET_KEY detected')
+            status['recommendations'].append('Use a cryptographically secure secret key')
+        
+        # Check SSL configuration in production
+        if self.mode == CSRFMode.PRODUCTION:
+            if not self.config.ssl_strict:
+                status['recommendations'].append('Enable SSL strict mode for production')
+        
+        return status
+    
+    def get_metrics(self) -> Dict[str, Any]:
+        """Get CSRF protection metrics"""
+        return {
+            'mode': self.mode.value,
+            'enabled': self.is_enabled,
+            'exempt_routes_count': len(self._exempt_routes),
+            'exempt_views_count': len(self._exempt_views),
+            'time_limit': self.config.time_limit,
+            'methods_protected': len(self.config.methods)
+        }

--- a/dash_csrf_plugin/plugin.py
+++ b/dash_csrf_plugin/plugin.py
@@ -1,0 +1,100 @@
+import logging
+from typing import Optional, Callable, Dict, List
+
+import dash
+
+from .config import CSRFConfig, CSRFMode
+from .manager import CSRFManager
+from .exceptions import CSRFConfigurationError
+
+logger = logging.getLogger(__name__)
+
+
+class DashCSRFPlugin:
+    """Main interface for integrating CSRF protection into Dash apps."""
+
+    def __init__(
+        self,
+        app: Optional[dash.Dash] = None,
+        config: Optional[CSRFConfig] = None,
+        mode: CSRFMode = CSRFMode.AUTO,
+    ):
+        self.app: Optional[dash.Dash] = None
+        self.config = config or CSRFConfig()
+        self.mode = mode
+        self.manager: Optional[CSRFManager] = None
+        self._initialized = False
+        self._hooks: Dict[str, List[Callable]] = {"before_init": [], "after_init": []}
+
+        if app is not None:
+            self.init_app(app)
+
+    def init_app(self, app: dash.Dash) -> None:
+        """Initialize the plugin with a Dash application."""
+        if not hasattr(app, "server"):
+            raise CSRFConfigurationError("Dash app must have a Flask server")
+
+        if self._initialized and self.app is app:
+            return
+
+        self.app = app
+        self._run_hooks("before_init")
+
+        if self.mode == CSRFMode.AUTO:
+            self.mode = self._detect_mode(app)
+
+        self.manager = CSRFManager(app, self.config, self.mode)
+        self.manager.init_app()
+        self._initialized = True
+
+        if not hasattr(app, "_plugins"):
+            app._plugins = {}
+        app._plugins["csrf"] = self
+
+        self._run_hooks("after_init")
+        logger.info("Dash CSRF Plugin initialized")
+
+    def _detect_mode(self, app: dash.Dash) -> CSRFMode:
+        if app.server.config.get("TESTING"):
+            return CSRFMode.TESTING
+        if app.server.config.get("DEBUG"):
+            return CSRFMode.DEVELOPMENT
+        return CSRFMode.PRODUCTION
+
+    def add_hook(self, name: str, func: Callable) -> None:
+        self._hooks.setdefault(name, []).append(func)
+
+    def _run_hooks(self, name: str) -> None:
+        for func in self._hooks.get(name, []):
+            try:
+                func()
+            except Exception as e:
+                logger.warning(f"Hook {name} failed: {e}")
+
+    def add_exempt_route(self, route: str) -> None:
+        if self.manager:
+            self.manager.add_exempt_route(route)
+
+    def add_exempt_view(self, view: str) -> None:
+        if self.manager:
+            self.manager.add_exempt_view(view)
+
+    def get_csrf_token(self) -> str:
+        if self.manager:
+            return self.manager.get_csrf_token()
+        return ""
+
+    def create_csrf_component(self, component_id: str = "csrf-token"):
+        if self.manager:
+            return self.manager.create_csrf_component(component_id)
+        return None
+
+    def get_status(self) -> Dict[str, str]:
+        return {
+            "initialized": self._initialized,
+            "mode": self.mode.value if isinstance(self.mode, CSRFMode) else str(self.mode),
+        }
+
+    @property
+    def is_enabled(self) -> bool:
+        return self.manager.is_enabled if self.manager else False

--- a/dash_csrf_plugin/utils.py
+++ b/dash_csrf_plugin/utils.py
@@ -1,0 +1,184 @@
+"""
+Utility functions for CSRF protection plugin
+"""
+
+import secrets
+import hashlib
+import logging
+from typing import Dict, Any, Optional, List
+from urllib.parse import urlparse
+import dash
+from flask import request, current_app
+
+logger = logging.getLogger(__name__)
+
+
+class CSRFUtils:
+    """Utility class for CSRF-related operations"""
+    
+    @staticmethod
+    def generate_secret_key(length: int = 32) -> str:
+        """Generate a cryptographically secure secret key"""
+        return secrets.token_urlsafe(length)
+    
+    @staticmethod
+    def is_safe_url(target: str, allowed_hosts: Optional[List[str]] = None) -> bool:
+        """Check if a URL is safe for redirects"""
+        if not target:
+            return False
+        
+        parsed = urlparse(target)
+        
+        # Relative URLs are safe
+        if not parsed.netloc:
+            return True
+        
+        # Check against allowed hosts
+        if allowed_hosts and parsed.netloc in allowed_hosts:
+            return True
+        
+        # Check against current request host
+        if hasattr(request, 'host') and parsed.netloc == request.host:
+            return True
+        
+        return False
+    
+    @staticmethod
+    def hash_token(token: str, algorithm: str = 'sha256') -> str:
+        """Hash a token using specified algorithm"""
+        hasher = hashlib.new(algorithm)
+        hasher.update(token.encode('utf-8'))
+        return hasher.hexdigest()
+    
+    @staticmethod
+    def detect_dash_app_type(app: dash.Dash) -> str:
+        """Detect the type of Dash application"""
+        if hasattr(app, '_dev_tools'):
+            if app._dev_tools.get('dev_tools_hot_reload', False):
+                return 'development'
+        
+        if hasattr(app, 'server'):
+            if app.server.config.get('TESTING', False):
+                return 'testing'
+            if app.server.config.get('DEBUG', False):
+                return 'development'
+        
+        return 'production'
+    
+    @staticmethod
+    def get_client_ip() -> str:
+        """Get client IP address from request"""
+        # Check for forwarded headers first
+        if request.headers.get('X-Forwarded-For'):
+            return request.headers.get('X-Forwarded-For').split(',')[0].strip()
+        elif request.headers.get('X-Real-IP'):
+            return request.headers.get('X-Real-IP')
+        else:
+            return request.remote_addr or 'unknown'
+    
+    @staticmethod
+    def log_csrf_attempt(success: bool, details: Dict[str, Any] = None) -> None:
+        """Log CSRF validation attempts"""
+        details = details or {}
+        ip = CSRFUtils.get_client_ip()
+        user_agent = request.headers.get('User-Agent', 'unknown')
+        
+        log_data = {
+            'success': success,
+            'ip': ip,
+            'user_agent': user_agent,
+            'path': request.path,
+            'method': request.method,
+            **details
+        }
+        
+        if success:
+            logger.info(f"CSRF validation successful: {log_data}")
+        else:
+            logger.warning(f"CSRF validation failed: {log_data}")
+    
+    @staticmethod
+    def extract_dash_routes(app: dash.Dash) -> List[str]:
+        """Extract Dash-specific routes from application"""
+        routes = []
+        
+        if hasattr(app, 'server') and hasattr(app.server, 'url_map'):
+            for rule in app.server.url_map.iter_rules():
+                if rule.rule.startswith('/_dash'):
+                    routes.append(rule.rule)
+        
+        return routes
+    
+    @staticmethod
+    def validate_config_security(config_dict: Dict[str, Any]) -> Dict[str, List[str]]:
+        """Validate configuration for security issues"""
+        issues = {
+            'warnings': [],
+            'errors': [],
+            'recommendations': []
+        }
+        
+        # Check secret key
+        secret_key = config_dict.get('secret_key')
+        if not secret_key:
+            issues['errors'].append('No secret key configured')
+        elif len(secret_key) < 16:
+            issues['warnings'].append('Secret key is too short (< 16 characters)')
+        elif secret_key in ['secret', 'dev', 'test', 'development']:
+            issues['errors'].append('Insecure default secret key detected')
+        
+        # Check SSL settings
+        if config_dict.get('ssl_strict', False) == False:
+            issues['warnings'].append('SSL strict mode is disabled')
+        
+        # Check time limit
+        time_limit = config_dict.get('time_limit', 3600)
+        if time_limit > 86400:  # 24 hours
+            issues['warnings'].append('CSRF token time limit is very long (>24h)')
+        elif time_limit < 300:  # 5 minutes
+            issues['warnings'].append('CSRF token time limit is very short (<5min)')
+        
+        # Check methods
+        methods = config_dict.get('methods', [])
+        if 'GET' in methods:
+            issues['warnings'].append('GET method should not require CSRF protection')
+        
+        return issues
+    
+    @staticmethod
+    def create_debug_info(app: dash.Dash, config) -> Dict[str, Any]:
+        """Create debug information for troubleshooting"""
+        return {
+            'dash_version': dash.__version__,
+            'flask_config': {
+                'SECRET_KEY': '***' if app.server.config.get('SECRET_KEY') else None,
+                'WTF_CSRF_ENABLED': app.server.config.get('WTF_CSRF_ENABLED'),
+                'DEBUG': app.server.config.get('DEBUG'),
+                'TESTING': app.server.config.get('TESTING')
+            },
+            'csrf_config': config.to_dict(),
+            'server_name': app.server.config.get('SERVER_NAME'),
+            'app_routes': [rule.rule for rule in app.server.url_map.iter_rules()],
+            'request_info': {
+                'method': request.method if request else None,
+                'path': request.path if request else None,
+                'headers': dict(request.headers) if request else None
+            }
+        }
+    
+    @staticmethod
+    def measure_performance(func):
+        """Decorator to measure function performance"""
+        import time
+        from functools import wraps
+        
+        @wraps(func)
+        def wrapper(*args, **kwargs):
+            start_time = time.time()
+            result = func(*args, **kwargs)
+            end_time = time.time()
+            
+            logger.debug(f"{func.__name__} took {end_time - start_time:.4f} seconds")
+            return result
+        
+        return wrapper

--- a/examples/advanced_usage.py
+++ b/examples/advanced_usage.py
@@ -1,0 +1,18 @@
+import dash
+from dash import html
+from dash_csrf_plugin import DashCSRFPlugin, CSRFConfig, CSRFMode
+
+config = CSRFConfig.for_production('super-secret-key', exempt_routes=['/health'])
+
+app = dash.Dash(__name__)
+app.server.config['SECRET_KEY'] = config.secret_key
+
+csrf = DashCSRFPlugin(app, config=config, mode=CSRFMode.ENABLED)
+
+app.layout = html.Div([
+    csrf.create_csrf_component(),
+    html.H1('Advanced CSRF Example')
+])
+
+if __name__ == '__main__':
+    app.run_server()

--- a/examples/basic_usage.py
+++ b/examples/basic_usage.py
@@ -1,0 +1,16 @@
+import dash
+from dash import html
+from dash_csrf_plugin import DashCSRFPlugin
+
+app = dash.Dash(__name__)
+app.server.config['SECRET_KEY'] = 'change-me'
+
+csrf = DashCSRFPlugin(app)
+
+app.layout = html.Div([
+    csrf.create_csrf_component(),
+    html.H1('Basic CSRF Example')
+])
+
+if __name__ == '__main__':
+    app.run_server(debug=True)

--- a/examples/production_setup.py
+++ b/examples/production_setup.py
@@ -1,0 +1,18 @@
+"""Example production configuration using the CSRF plugin"""
+
+import dash
+from dash_csrf_plugin import DashCSRFPlugin, CSRFConfig, CSRFMode
+
+app = dash.Dash(__name__)
+app.server.config['SECRET_KEY'] = 'prod-secret-key'
+
+config = CSRFConfig.for_production('prod-secret-key')
+csrf = DashCSRFPlugin(app, config=config, mode=CSRFMode.PRODUCTION)
+
+app.layout = dash.html.Div([
+    csrf.create_csrf_component(),
+    dash.html.H1('Production Setup')
+])
+
+if __name__ == '__main__':
+    app.run_server(debug=False)

--- a/examples/testing_setup.py
+++ b/examples/testing_setup.py
@@ -1,0 +1,17 @@
+"""Example testing configuration with CSRF disabled"""
+
+import dash
+from dash_csrf_plugin import DashCSRFPlugin, CSRFMode
+
+app = dash.Dash(__name__)
+app.server.config['SECRET_KEY'] = 'test-secret-key'
+
+csrf = DashCSRFPlugin(app, mode=CSRFMode.TESTING)
+
+app.layout = dash.html.Div([
+    csrf.create_csrf_component(),
+    dash.html.H1('Testing Setup')
+])
+
+if __name__ == '__main__':
+    app.run_server(debug=True)

--- a/requirements.txt
+++ b/requirements.txt
@@ -58,3 +58,4 @@ cryptography>=41.0.3
 flask-wtf>=1.2.1
 Flask-Babel>=4.0.0
 babel>=2.14.0
+click>=8.1.0

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,29 @@
+from setuptools import setup, find_packages
+import pathlib
+
+BASE_DIR = pathlib.Path(__file__).parent
+
+with open(BASE_DIR / 'README.md', encoding='utf-8') as f:
+    long_description = f.read()
+
+
+def parse_requirements(path: str):
+    reqs = []
+    with open(BASE_DIR / path, 'r') as f:
+        for line in f:
+            line = line.strip()
+            if line and not line.startswith('#'):
+                reqs.append(line)
+    return reqs
+
+setup(
+    name='dash-csrf-plugin',
+    version='0.1.0',
+    description='CSRF protection plugin for Dash applications',
+    long_description=long_description,
+    long_description_content_type='text/markdown',
+    packages=find_packages(exclude=('tests*', 'examples*')),
+    install_requires=parse_requirements('requirements.txt'),
+    entry_points={'console_scripts': ['dash-csrf-plugin=dash_csrf_plugin.cli:cli']},
+    python_requires='>=3.8',
+)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,33 @@
+"""
+Pytest configuration for CSRF plugin tests
+"""
+
+import pytest
+import dash
+from dash_csrf_plugin import DashCSRFPlugin, CSRFConfig, CSRFMode
+
+
+@pytest.fixture(scope="session")
+def test_config():
+    return CSRFConfig.for_testing()
+
+
+@pytest.fixture
+def dash_app():
+    app = dash.Dash(__name__)
+    app.server.config.update({
+        'SECRET_KEY': 'test-secret-key',
+        'TESTING': True,
+        'WTF_CSRF_ENABLED': False,
+    })
+    return app
+
+
+@pytest.fixture
+def csrf_plugin(dash_app, test_config):
+    return DashCSRFPlugin(dash_app, config=test_config, mode=CSRFMode.TESTING)
+
+
+@pytest.fixture
+def client(dash_app):
+    return dash_app.server.test_client()

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -1,0 +1,209 @@
+"""
+Comprehensive tests for the CSRF protection plugin
+"""
+
+import pytest
+import os
+import dash
+from dash import html, dcc, Input, Output
+from unittest.mock import patch, MagicMock
+from flask import Flask
+
+from dash_csrf_plugin import (
+    DashCSRFPlugin,
+    CSRFConfig,
+    CSRFMode,
+    CSRFError,
+    CSRFConfigurationError,
+)
+
+
+class TestCSRFConfig:
+    """Test CSRF configuration functionality"""
+
+    def test_default_config(self):
+        config = CSRFConfig(secret_key="test")
+        assert config.enabled is True
+        assert config.time_limit == 3600
+        assert config.ssl_strict is True
+        assert 'POST' in config.methods
+
+    def test_development_config(self):
+        config = CSRFConfig.for_development()
+        assert config.enabled is False
+        assert config.ssl_strict is False
+        assert config.secret_key == 'dev-secret-key-change-in-production'
+
+    def test_production_config(self):
+        config = CSRFConfig.for_production('production-secret')
+        assert config.enabled is True
+        assert config.ssl_strict is True
+        assert config.secret_key == 'production-secret'
+
+    def test_testing_config(self):
+        config = CSRFConfig.for_testing()
+        assert config.enabled is False
+        assert config.secret_key == 'test-secret-key'
+
+    def test_from_environment(self, monkeypatch):
+        env_vars = {
+            'CSRF_ENABLED': 'true',
+            'CSRF_SECRET_KEY': 'env-secret',
+            'CSRF_TIME_LIMIT': '1800',
+            'CSRF_SSL_STRICT': 'false',
+        }
+        monkeypatch.setenv('CSRF_ENABLED', 'true')
+        monkeypatch.setenv('CSRF_SECRET_KEY', 'env-secret')
+        monkeypatch.setenv('CSRF_TIME_LIMIT', '1800')
+        monkeypatch.setenv('CSRF_SSL_STRICT', 'false')
+        config = CSRFConfig.from_environment()
+        assert config.enabled is True
+        assert config.secret_key == 'env-secret'
+        assert config.time_limit == 1800
+        assert config.ssl_strict is False
+
+    def test_config_validation(self):
+        with pytest.raises(ValueError):
+            CSRFConfig(enabled=True, secret_key=None)
+        with pytest.raises(ValueError):
+            CSRFConfig(time_limit=0, secret_key="x")
+
+    def test_config_to_dict(self):
+        config = CSRFConfig(secret_key='test-secret')
+        config_dict = config.to_dict()
+        assert 'enabled' in config_dict
+        assert config_dict['secret_key'] == '***'
+        assert config_dict['time_limit'] == 3600
+
+
+class TestDashCSRFPlugin:
+    @pytest.fixture
+    def dash_app(self):
+        app = dash.Dash(__name__)
+        app.server.config['SECRET_KEY'] = 'test-secret'
+        return app
+
+    def test_plugin_creation(self, dash_app):
+        plugin = DashCSRFPlugin()
+        assert plugin.app is None
+        assert not plugin._initialized
+
+    def test_plugin_initialization(self, dash_app):
+        plugin = DashCSRFPlugin(dash_app, mode=CSRFMode.TESTING)
+        assert plugin.app == dash_app
+        assert plugin._initialized
+        assert plugin.mode == CSRFMode.TESTING
+
+    def test_auto_mode_detection(self, dash_app):
+        dash_app.server.config['DEBUG'] = True
+        plugin = DashCSRFPlugin(dash_app, mode=CSRFMode.AUTO)
+        assert plugin.mode == CSRFMode.DEVELOPMENT
+        dash_app.server.config['DEBUG'] = False
+        plugin = DashCSRFPlugin(mode=CSRFMode.AUTO)
+        plugin.init_app(dash_app)
+        assert plugin.mode == CSRFMode.PRODUCTION
+
+    def test_exempt_routes(self, dash_app):
+        plugin = DashCSRFPlugin(dash_app, mode=CSRFMode.TESTING)
+        plugin.add_exempt_route('/custom-route')
+        assert '/custom-route' in plugin.manager._exempt_routes
+        assert '/_dash-dependencies' in plugin.manager._exempt_routes
+
+    def test_csrf_token_generation(self, dash_app):
+        plugin = DashCSRFPlugin(dash_app, mode=CSRFMode.ENABLED)
+        with dash_app.server.app_context():
+            with patch('dash_csrf_plugin.manager.generate_csrf') as mock_generate:
+                mock_generate.return_value = 'test-token'
+                token = plugin.get_csrf_token()
+                assert token == 'test-token'
+
+    def test_csrf_component_creation(self, dash_app):
+        plugin = DashCSRFPlugin(dash_app, mode=CSRFMode.TESTING)
+        component = plugin.create_csrf_component()
+        assert component is not None
+
+    def test_plugin_status(self, dash_app):
+        plugin = DashCSRFPlugin(dash_app, mode=CSRFMode.TESTING)
+        status = plugin.get_status()
+        assert 'initialized' in status
+        assert 'mode' in status
+        assert status['initialized'] is True
+        assert status['mode'] == 'testing'
+
+    def test_plugin_hooks(self, dash_app):
+        plugin = DashCSRFPlugin(dash_app, mode=CSRFMode.TESTING)
+        hook_called = False
+
+        def test_hook():
+            nonlocal hook_called
+            hook_called = True
+
+        plugin.add_hook('before_init', test_hook)
+        assert len(plugin._hooks['before_init']) == 1
+        plugin._run_hooks('before_init')
+        assert hook_called
+
+    def test_configuration_error(self):
+        invalid_app = MagicMock()
+        if hasattr(invalid_app, 'server'):
+            del invalid_app.server
+        with pytest.raises(CSRFConfigurationError):
+            DashCSRFPlugin(invalid_app)
+
+
+class TestCSRFIntegration:
+    @pytest.fixture
+    def app_with_csrf(self):
+        app = dash.Dash(__name__)
+        app.server.config['SECRET_KEY'] = 'test-secret'
+        plugin = DashCSRFPlugin(app, mode=CSRFMode.TESTING)
+        app.layout = html.Div([
+            plugin.create_csrf_component(),
+            html.Button('Test', id='test-btn', n_clicks=0),
+            html.Div(id='output')
+        ])
+
+        @app.callback(Output('output', 'children'), Input('test-btn', 'n_clicks'))
+        def update_output(n_clicks):
+            return f'Clicks: {n_clicks}'
+        return app, plugin
+
+    def test_app_loads_successfully(self, app_with_csrf):
+        app, plugin = app_with_csrf
+        with app.server.test_client() as client:
+            response = client.get('/')
+            assert response.status_code == 200
+
+    def test_health_endpoint(self, app_with_csrf):
+        app, plugin = app_with_csrf
+        with app.server.test_client() as client:
+            response = client.get('/health')
+            assert response.status_code == 200
+
+    def test_csrf_disabled_in_testing(self, app_with_csrf):
+        app, plugin = app_with_csrf
+        assert not plugin.is_enabled
+        assert app.server.config.get('WTF_CSRF_ENABLED') is False
+
+
+class TestCSRFModes:
+    def test_development_mode(self):
+        app = dash.Dash(__name__)
+        app.server.config['SECRET_KEY'] = 'test'
+        plugin = DashCSRFPlugin(app, mode=CSRFMode.DEVELOPMENT)
+        assert not plugin.is_enabled
+        assert app.server.config.get('WTF_CSRF_ENABLED') is False
+
+    def test_production_mode(self):
+        app = dash.Dash(__name__)
+        app.server.config['SECRET_KEY'] = 'test'
+        plugin = DashCSRFPlugin(app, mode=CSRFMode.PRODUCTION)
+        assert plugin.is_enabled
+        assert app.server.config.get('WTF_CSRF_ENABLED') is True
+
+    def test_disabled_mode(self):
+        app = dash.Dash(__name__)
+        app.server.config['SECRET_KEY'] = 'test'
+        plugin = DashCSRFPlugin(app, mode=CSRFMode.DISABLED)
+        assert not plugin.is_enabled
+        assert app.server.config.get('WTF_CSRF_ENABLED') is False


### PR DESCRIPTION
## Summary
- add a production-ready CSRF plugin with manager, config, utils and CLI
- provide examples of using the plugin
- include tests for the plugin
- integrate package metadata via setup.py
- document the new plugin in the README and add dependency

## Testing
- `python tests/test_modular_system.py` *(fails: ModuleNotFoundError: No module named 'pandas')*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'dash')*

------
https://chatgpt.com/codex/tasks/task_e_68529f9e1514832095f490e18e737782