### PR TITLE
Fix typing import for List

### DIFF
--- a/enhanced_migration_tool.py
+++ b/enhanced_migration_tool.py
@@ -9,6 +9,7 @@ import shutil
 from pathlib import Path
 from datetime import datetime
 import re
+from typing import List
 
 def create_enhanced_csrf_plugin():
     """Create the enhanced CSRF plugin with your improvements"""


### PR DESCRIPTION
## Summary
- ensure `List` is imported in `enhanced_migration_tool.py`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'dash')*

------
https://chatgpt.com/codex/tasks/task_e_6852b912e3cc8320be3440636035ca8f