### PR TITLE
Restore functional app.py with CSRF workaround

### DIFF
--- a/app.py
+++ b/app.py
@@ -1,199 +1,149 @@
-# app.py - Fixed version without complex dependencies
+# app.py - Main Application Entry Point with CSRF Fix
 """
-Working Dash application that eliminates:
-1. CSRF session token errors
-2. Import/module dependency issues
-3. Complex configuration requirements
+Yōsai Intel Dashboard
 
-This is a complete, standalone solution.
+This version restores the full application from ``app_backup_20250618_211158.py``
+while applying the simplified CSRF workaround that proved successful in the
+example file. CSRF protection via ``flask_wtf`` is disabled to avoid the
+"CSRF session token is missing" error.
 """
 
 import os
-import dash
-from dash import html, dcc, Input, Output
-import plotly.graph_objs as go
-import pandas as pd
-from datetime import datetime
+import sys
+import logging
+from pathlib import Path
+from typing import Optional, Any
 
-# IMMEDIATE CSRF FIX - Prevents "CSRF session token is missing" error
-os.environ['WTF_CSRF_ENABLED'] = 'False'
+# ---- CSRF workaround -----------------------------------------------------
+# Disable CSRF checks before any Dash/Flask modules are imported
+os.environ["WTF_CSRF_ENABLED"] = "False"
 
-print("🚀 Starting Fixed Yosai Dashboard...")
-
-# Create Dash application
-app = dash.Dash(
-    __name__,
-    external_stylesheets=[
-        'https://cdn.jsdelivr.net/npm/bootstrap@5.1.3/dist/css/bootstrap.min.css'
-    ]
-)
-
-# Configure Flask server to prevent CSRF errors
-app.server.config.update({
-    'SECRET_KEY': 'fixed-secret-key-change-in-production',
-    'WTF_CSRF_ENABLED': False,  # This prevents the CSRF error
-    'DEBUG': True
-})
-
-print("✅ CSRF protection configured - no more token errors!")
-
-# Sample data for the dashboard
-def create_sample_data():
-    """Create sample business intelligence data"""
-    dates = pd.date_range('2024-01-01', periods=30, freq='D')
-    return pd.DataFrame({
-        'date': dates,
-        'revenue': [10000 + i * 500 for i in range(30)],
-        'users': [1000 + i * 25 for i in range(30)],
-        'conversion': [0.05 + (i % 10) * 0.01 for i in range(30)]
-    })
-
-df = create_sample_data()
-
-# Application layout
-app.layout = html.Div([
-    # Header
-    html.Div(className="bg-success text-white p-4 mb-4", children=[
-        html.H1("🛡️ Yosai Intelligence Dashboard - FIXED", className="mb-2"),
-        html.P("CSRF errors eliminated • Import issues resolved • Fully functional")
-    ]),
-    
-    # Status alert
-    html.Div(className="container mb-4", children=[
-        html.Div(className="alert alert-success", children=[
-            html.H4("✅ All Issues Resolved!"),
-            html.P("• CSRF session token errors: FIXED"),
-            html.P("• Import/module errors: FIXED"), 
-            html.P("• Configuration complexity: SIMPLIFIED"),
-            html.P("• Application status: FULLY WORKING")
-        ])
-    ]),
-    
-    # Dashboard content
-    html.Div(className="container", children=[
-        html.Div(className="row mb-4", children=[
-            html.Div(className="col-md-4", children=[
-                html.Div(className="card", children=[
-                    html.Div(className="card-body", children=[
-                        html.H5("Dashboard Controls"),
-                        dcc.Dropdown(
-                            id="metric-dropdown",
-                            options=[
-                                {'label': '💰 Revenue', 'value': 'revenue'},
-                                {'label': '👥 Users', 'value': 'users'},
-                                {'label': '📈 Conversion', 'value': 'conversion'}
-                            ],
-                            value='revenue'
-                        ),
-                        html.Br(),
-                        html.Button("Refresh", id="refresh-btn", n_clicks=0, 
-                                  className="btn btn-primary")
-                    ])
-                ])
-            ]),
-            
-            html.Div(className="col-md-8", children=[
-                html.Div(className="card", children=[
-                    html.Div(className="card-body", children=[
-                        html.H5("Business Metrics"),
-                        dcc.Graph(id="main-chart")
-                    ])
-                ])
-            ])
-        ]),
-        
-        html.Div(className="row", children=[
-            html.Div(className="col-md-6", children=[
-                html.Div(className="card", children=[
-                    html.Div(className="card-body", children=[
-                        html.H5("System Status"),
-                        html.Div(id="system-status")
-                    ])
-                ])
-            ]),
-            
-            html.Div(className="col-md-6", children=[
-                html.Div(className="card", children=[
-                    html.Div(className="card-body", children=[
-                        html.H5("Test Area"),
-                        html.Button("Test CSRF Fix", id="test-btn", n_clicks=0,
-                                  className="btn btn-success"),
-                        html.Div(id="test-result", className="mt-2")
-                    ])
-                ])
-            ])
-        ])
-    ])
-])
-
-# Callbacks that would previously fail with CSRF errors
-@app.callback(
-    Output('main-chart', 'figure'),
-    [Input('metric-dropdown', 'value'), Input('refresh-btn', 'n_clicks')]
-)
-def update_chart(metric, n_clicks):
-    """Update main chart - this would fail with CSRF errors before"""
-    
-    fig = go.Figure()
-    fig.add_trace(go.Scatter(
-        x=df['date'],
-        y=df[metric],
-        mode='lines+markers',
-        name=metric.title()
-    ))
-    
-    fig.update_layout(
-        title=f"{metric.title()} Over Time (Updates: {n_clicks})",
-        template="plotly_white"
-    )
-    
-    return fig
-
-@app.callback(
-    Output('system-status', 'children'),
-    [Input('refresh-btn', 'n_clicks')]
-)
-def update_status(n_clicks):
-    """Show system status"""
-    return html.Div([
-        html.P(f"🟢 Status: Running"),
-        html.P(f"🛡️ CSRF: Disabled (No Errors)"),
-        html.P(f"📊 Data: Loaded"),
-        html.P(f"🔄 Updates: {n_clicks}"),
-        html.P(f"⏰ Time: {datetime.now().strftime('%H:%M:%S')}")
-    ])
-
-@app.callback(
-    Output('test-result', 'children'),
-    [Input('test-btn', 'n_clicks')]
-)
-def test_csrf_fix(n_clicks):
-    """Test that CSRF fix is working"""
-    if n_clicks > 0:
-        return html.Div(className="alert alert-success", children=[
-            f"✅ Test #{n_clicks} passed! No CSRF errors occurred."
-        ])
-    return ""
-
-# Health check endpoint
-@app.server.route('/health')
-def health():
-    return {'status': 'healthy', 'csrf_fixed': True}
-
-# Run the application
-if __name__ == '__main__':
-    print("\n" + "="*50)
-    print("🎉 YOSAI DASHBOARD - ALL ISSUES FIXED")
-    print("="*50)
-    print("🌐 URL: http://127.0.0.1:8050")
-    print("✅ CSRF errors: ELIMINATED")
-    print("✅ Import errors: RESOLVED") 
-    print("✅ Dependencies: SIMPLIFIED")
-    print("="*50)
-    
-    # FIXED: Compatible with all Dash versions
+# -------------------------------------------------------------------------
+# Load environment variables early
 try:
-    app.run(debug=True, port=8050)
-except AttributeError:
-    # Fallback for older Dash versions
-    app.run_server(debug=True, port=8050)
+    from dotenv import load_dotenv
+    env_file = Path(".env")
+    if env_file.exists():
+        load_dotenv(env_file, override=True)
+        print("✅ Loaded .env file")
+    else:
+        print("⚠️  .env file not found")
+except ImportError:
+    print("⚠️  python-dotenv not installed")
+
+# Ensure required variables are set for development
+required_vars = {
+    "DB_HOST": "localhost",
+    "SECRET_KEY": "dev-secret-change-in-production-12345",
+    "AUTH0_CLIENT_ID": "your-client-id",
+    "AUTH0_CLIENT_SECRET": "your-client-secret",
+    "AUTH0_DOMAIN": "your-domain.auth0.com",
+    "AUTH0_AUDIENCE": "your-api-audience",
+    "YOSAI_ENV": "development",
+}
+for var, default in required_vars.items():
+    if not os.getenv(var):
+        os.environ[var] = default
+
+# -------------------------------------------------------------------------
+# Main application logic
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s - %(name)s - %(levelname)s - %(message)s",
+)
+logger = logging.getLogger(__name__)
+
+
+def main() -> None:
+    """Run the dashboard using the YAML configuration system."""
+    try:
+        from core.app_factory import create_application
+        from config.yaml_config import ConfigurationManager
+
+        # Determine which configuration file to load
+        config_path = get_config_path()
+
+        # Load configuration
+        config_manager = ConfigurationManager()
+        config_manager.load_configuration(config_path)
+        config_manager.print_startup_info()
+
+        # Create the Dash application
+        app = create_application()
+        if app is None:
+            print("❌ Failed to create dashboard application")
+            sys.exit(1)
+
+        # Apply CSRF workaround to the Flask server
+        app.server.config.setdefault("SECRET_KEY", os.getenv("SECRET_KEY"))
+        app.server.config["WTF_CSRF_ENABLED"] = False
+
+        # Configure logging level from configuration
+        app_config = config_manager.app_config
+        logging.getLogger().setLevel(getattr(logging, app_config.log_level.upper()))
+
+        # Run the application
+        app.run(debug=app_config.debug, host=app_config.host, port=app_config.port)
+
+    except KeyboardInterrupt:
+        print("\n👋 Dashboard stopped by user")
+        sys.exit(0)
+    except Exception as e:
+        logger.error(f"Critical error in main: {e}")
+        print(f"❌ Critical error: {e}")
+        sys.exit(1)
+
+
+def get_config_path() -> Optional[str]:
+    """Select the configuration file based on environment variables."""
+    from core.secret_manager import SecretManager
+
+    manager = SecretManager()
+    try:
+        config_file = manager.get("YOSAI_CONFIG_FILE")
+    except KeyError:
+        config_file = None
+    if config_file and Path(config_file).exists():
+        print(f"📋 Using config file from YOSAI_CONFIG_FILE: {config_file}")
+        return config_file
+
+    env = manager.get("YOSAI_ENV", "development").lower()
+    env_config_map = {
+        "production": "config/production.yaml",
+        "prod": "config/production.yaml",
+        "test": "config/test.yaml",
+        "testing": "config/test.yaml",
+        "development": "config/config.yaml",
+        "dev": "config/config.yaml",
+    }
+    config_path = env_config_map.get(env, "config/config.yaml")
+    if Path(config_path).exists():
+        print(f"📋 Using environment config: {config_path} (YOSAI_ENV={env})")
+        return config_path
+    print(f"⚠️  Config file not found: {config_path}, using defaults")
+    return None
+
+
+# -------------------------------------------------------------------------
+# WSGI helpers
+
+def get_app() -> Optional[Any]:
+    """Return the Dash app instance for WSGI servers."""
+    try:
+        from core.app_factory import create_application
+        app = create_application()
+        if app:
+            app.server.config.setdefault("SECRET_KEY", os.getenv("SECRET_KEY"))
+            app.server.config["WTF_CSRF_ENABLED"] = False
+        return app
+    except Exception as e:
+        logger.error(f"Error creating WSGI app: {e}")
+        return None
+
+
+# Expose global app/server for WSGI
+app = get_app()
+server = app.server if app is not None else None
+
+if __name__ == "__main__":
+    main()

--- a/app_simple_backup.py
+++ b/app_simple_backup.py
@@ -1,0 +1,199 @@
+# app.py - Fixed version without complex dependencies
+"""
+Working Dash application that eliminates:
+1. CSRF session token errors
+2. Import/module dependency issues
+3. Complex configuration requirements
+
+This is a complete, standalone solution.
+"""
+
+import os
+import dash
+from dash import html, dcc, Input, Output
+import plotly.graph_objs as go
+import pandas as pd
+from datetime import datetime
+
+# IMMEDIATE CSRF FIX - Prevents "CSRF session token is missing" error
+os.environ['WTF_CSRF_ENABLED'] = 'False'
+
+print("🚀 Starting Fixed Yosai Dashboard...")
+
+# Create Dash application
+app = dash.Dash(
+    __name__,
+    external_stylesheets=[
+        'https://cdn.jsdelivr.net/npm/bootstrap@5.1.3/dist/css/bootstrap.min.css'
+    ]
+)
+
+# Configure Flask server to prevent CSRF errors
+app.server.config.update({
+    'SECRET_KEY': 'fixed-secret-key-change-in-production',
+    'WTF_CSRF_ENABLED': False,  # This prevents the CSRF error
+    'DEBUG': True
+})
+
+print("✅ CSRF protection configured - no more token errors!")
+
+# Sample data for the dashboard
+def create_sample_data():
+    """Create sample business intelligence data"""
+    dates = pd.date_range('2024-01-01', periods=30, freq='D')
+    return pd.DataFrame({
+        'date': dates,
+        'revenue': [10000 + i * 500 for i in range(30)],
+        'users': [1000 + i * 25 for i in range(30)],
+        'conversion': [0.05 + (i % 10) * 0.01 for i in range(30)]
+    })
+
+df = create_sample_data()
+
+# Application layout
+app.layout = html.Div([
+    # Header
+    html.Div(className="bg-success text-white p-4 mb-4", children=[
+        html.H1("🛡️ Yosai Intelligence Dashboard - FIXED", className="mb-2"),
+        html.P("CSRF errors eliminated • Import issues resolved • Fully functional")
+    ]),
+    
+    # Status alert
+    html.Div(className="container mb-4", children=[
+        html.Div(className="alert alert-success", children=[
+            html.H4("✅ All Issues Resolved!"),
+            html.P("• CSRF session token errors: FIXED"),
+            html.P("• Import/module errors: FIXED"), 
+            html.P("• Configuration complexity: SIMPLIFIED"),
+            html.P("• Application status: FULLY WORKING")
+        ])
+    ]),
+    
+    # Dashboard content
+    html.Div(className="container", children=[
+        html.Div(className="row mb-4", children=[
+            html.Div(className="col-md-4", children=[
+                html.Div(className="card", children=[
+                    html.Div(className="card-body", children=[
+                        html.H5("Dashboard Controls"),
+                        dcc.Dropdown(
+                            id="metric-dropdown",
+                            options=[
+                                {'label': '💰 Revenue', 'value': 'revenue'},
+                                {'label': '👥 Users', 'value': 'users'},
+                                {'label': '📈 Conversion', 'value': 'conversion'}
+                            ],
+                            value='revenue'
+                        ),
+                        html.Br(),
+                        html.Button("Refresh", id="refresh-btn", n_clicks=0, 
+                                  className="btn btn-primary")
+                    ])
+                ])
+            ]),
+            
+            html.Div(className="col-md-8", children=[
+                html.Div(className="card", children=[
+                    html.Div(className="card-body", children=[
+                        html.H5("Business Metrics"),
+                        dcc.Graph(id="main-chart")
+                    ])
+                ])
+            ])
+        ]),
+        
+        html.Div(className="row", children=[
+            html.Div(className="col-md-6", children=[
+                html.Div(className="card", children=[
+                    html.Div(className="card-body", children=[
+                        html.H5("System Status"),
+                        html.Div(id="system-status")
+                    ])
+                ])
+            ]),
+            
+            html.Div(className="col-md-6", children=[
+                html.Div(className="card", children=[
+                    html.Div(className="card-body", children=[
+                        html.H5("Test Area"),
+                        html.Button("Test CSRF Fix", id="test-btn", n_clicks=0,
+                                  className="btn btn-success"),
+                        html.Div(id="test-result", className="mt-2")
+                    ])
+                ])
+            ])
+        ])
+    ])
+])
+
+# Callbacks that would previously fail with CSRF errors
+@app.callback(
+    Output('main-chart', 'figure'),
+    [Input('metric-dropdown', 'value'), Input('refresh-btn', 'n_clicks')]
+)
+def update_chart(metric, n_clicks):
+    """Update main chart - this would fail with CSRF errors before"""
+    
+    fig = go.Figure()
+    fig.add_trace(go.Scatter(
+        x=df['date'],
+        y=df[metric],
+        mode='lines+markers',
+        name=metric.title()
+    ))
+    
+    fig.update_layout(
+        title=f"{metric.title()} Over Time (Updates: {n_clicks})",
+        template="plotly_white"
+    )
+    
+    return fig
+
+@app.callback(
+    Output('system-status', 'children'),
+    [Input('refresh-btn', 'n_clicks')]
+)
+def update_status(n_clicks):
+    """Show system status"""
+    return html.Div([
+        html.P(f"🟢 Status: Running"),
+        html.P(f"🛡️ CSRF: Disabled (No Errors)"),
+        html.P(f"📊 Data: Loaded"),
+        html.P(f"🔄 Updates: {n_clicks}"),
+        html.P(f"⏰ Time: {datetime.now().strftime('%H:%M:%S')}")
+    ])
+
+@app.callback(
+    Output('test-result', 'children'),
+    [Input('test-btn', 'n_clicks')]
+)
+def test_csrf_fix(n_clicks):
+    """Test that CSRF fix is working"""
+    if n_clicks > 0:
+        return html.Div(className="alert alert-success", children=[
+            f"✅ Test #{n_clicks} passed! No CSRF errors occurred."
+        ])
+    return ""
+
+# Health check endpoint
+@app.server.route('/health')
+def health():
+    return {'status': 'healthy', 'csrf_fixed': True}
+
+# Run the application
+if __name__ == '__main__':
+    print("\n" + "="*50)
+    print("🎉 YOSAI DASHBOARD - ALL ISSUES FIXED")
+    print("="*50)
+    print("🌐 URL: http://127.0.0.1:8050")
+    print("✅ CSRF errors: ELIMINATED")
+    print("✅ Import errors: RESOLVED") 
+    print("✅ Dependencies: SIMPLIFIED")
+    print("="*50)
+    
+    # FIXED: Compatible with all Dash versions
+try:
+    app.run(debug=True, port=8050)
+except AttributeError:
+    # Fallback for older Dash versions
+    app.run_server(debug=True, port=8050)


### PR DESCRIPTION
## Summary
- keep previous example app as `app_simple_backup.py`
- revive full dashboard logic in `app.py`
- disable CSRF checks in the main entrypoint to avoid missing token errors

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'dash')*

------
https://chatgpt.com/codex/tasks/task_e_6852bf145ef48320abf604baab70cbba