### PR TITLE
Fix missing config module

### DIFF
--- a/config/__init__.py
+++ b/config/__init__.py
@@ -1,0 +1,15 @@
+"""Compatibility configuration package."""
+from importlib import import_module
+
+# Lazy modules pointing to new location
+_yaml = import_module('core.plugins.config.yaml_config')
+_database = import_module('core.plugins.config.database_manager')
+_cache = import_module('core.plugins.config.cache_manager')
+
+__all__ = []  # will extend below
+
+# Re-export top-level names from submodules for backward compatibility
+for _mod in (_yaml, _database, _cache):
+    globals().update({k: getattr(_mod, k) for k in getattr(_mod, '__all__', [])})
+    __all__.extend(getattr(_mod, '__all__', []))
+

--- a/config/cache_manager.py
+++ b/config/cache_manager.py
@@ -1,0 +1,1 @@
+from core.plugins.config.cache_manager import *

--- a/config/database_manager.py
+++ b/config/database_manager.py
@@ -1,0 +1,1 @@
+from core.plugins.config.database_manager import *

--- a/config/yaml_config.py
+++ b/config/yaml_config.py
@@ -1,0 +1,1 @@
+from core.plugins.config.yaml_config import *

--- a/core/plugins/config/yaml_config.py
+++ b/core/plugins/config/yaml_config.py
@@ -272,7 +272,8 @@ class ConfigurationManager:
         env = environment or manager.get("ENVIRONMENT", "development")
 
         # Determine config file path based on environment
-        config_dir = Path("config")
+        # Look for configuration files relative to this module
+        config_dir = Path(__file__).resolve().parent
         config_path = None
 
         # Try environment-specific file first


### PR DESCRIPTION
## Summary
- add `config` compatibility package so imports succeed
- adjust `yaml_config` to load YAML files relative to package

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'dash')*
- `pip install -r requirements.txt` *(fails: Tunnel connection failed: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_6852c0b1d20c8320b337dca46ac64e36