### PR TITLE
Use LazyString-safe decorators

### DIFF
--- a/dashboard/layout/navbar.py
+++ b/dashboard/layout/navbar.py
@@ -6,7 +6,10 @@ Navigation bar component with complete type safety
 import datetime
 from typing import TYPE_CHECKING
 from flask_babel import lazy_gettext as _l
-from utils.lazystring_handler import sanitize_lazystring_recursive
+from utils.lazystring_handler import (
+    sanitize_lazystring_recursive,
+    lazystring_safe_callback,
+)
 
 if TYPE_CHECKING:
     import dash_bootstrap_components as dbc
@@ -173,6 +176,7 @@ def register_navbar_callbacks(app):
             Input("live-time", "id"),
             prevent_initial_call=False,
         )
+        @lazystring_safe_callback
         def update_time(_):
             try:
                 return f"Live Time: {datetime.datetime.now().strftime('%Y-%m-%d %H:%M:%S')}"

--- a/pages/deep_analytics.py
+++ b/pages/deep_analytics.py
@@ -10,7 +10,10 @@ from flask_babel import lazy_gettext as _l
 from core.auth import role_required
 import dash_bootstrap_components as dbc
 from typing import List, Dict, Any, Optional, Tuple, Union
-from utils.lazystring_handler import sanitize_lazystring_recursive
+from utils.lazystring_handler import (
+    sanitize_lazystring_recursive,
+    lazystring_safe_callback,
+)
 
 # Import the modular analytics components with safe fallbacks
 try:
@@ -64,7 +67,7 @@ if not ANALYTICS_COMPONENTS_AVAILABLE:
 
 def layout():
     """Deep Analytics page layout - same as before"""
-    return dbc.Container(
+    layout_container = dbc.Container(
         [
             # Page header
             dbc.Row(
@@ -94,6 +97,7 @@ def layout():
         fluid=True,
         className="p-4",
     )
+    return sanitize_lazystring_recursive(layout_container)
 
 
 def register_analytics_callbacks(app, container=None):
@@ -114,6 +118,7 @@ def register_analytics_callbacks(app, container=None):
         prevent_initial_call=True,
     )
     @role_required("admin")
+    @lazystring_safe_callback
     def process_uploaded_files(
         contents_list: Optional[Union[str, List[str]]],
         filename_list: Optional[Union[str, List[str]]],


### PR DESCRIPTION
## Summary
- apply `lazystring_safe_callback` to navbar and analytics callbacks
- sanitize the deep analytics layout

## Testing
- `python -m py_compile dashboard/layout/navbar.py pages/deep_analytics.py utils/lazystring_handler.py`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'dash')*

------
https://chatgpt.com/codex/tasks/task_e_6852c610c7c48320ad8907f8125f43bc