### PR TITLE
Fix LazyString serialization in layouts

### DIFF
--- a/components/bottom_panel.py
+++ b/components/bottom_panel.py
@@ -2,6 +2,7 @@
 
 from dash import html, dcc
 from flask_babel import lazy_gettext as _l
+from utils.lazystring_handler import sanitize_lazystring_recursive
 
 layout = html.Div(
     [
@@ -98,3 +99,6 @@ layout = html.Div(
     ],
     className="bottom-panel",
 )
+
+# Sanitize to avoid LazyString serialization issues
+layout = sanitize_lazystring_recursive(layout)

--- a/components/incident_alerts_panel.py
+++ b/components/incident_alerts_panel.py
@@ -3,6 +3,7 @@
 from dash import html, dcc, callback, Output, Input, State
 import dash_bootstrap_components as dbc
 from flask_babel import lazy_gettext as _l
+from utils.lazystring_handler import sanitize_lazystring_recursive
 
 # Categories and their properties
 TICKET_CATEGORIES = [
@@ -124,3 +125,6 @@ layout = html.Div(
     ],
     className="incident-alert-panel",
 )
+
+# Sanitize layout to ensure LazyString objects are converted to plain strings
+layout = sanitize_lazystring_recursive(layout)

--- a/components/map_panel.py
+++ b/components/map_panel.py
@@ -6,6 +6,7 @@ import dash_leaflet as dl
 from dash_leaflet import Marker, TileLayer, Tooltip, Popup, ScaleControl, ZoomControl
 from dash import html, dcc, Output, Input, callback_context, no_update
 from flask_babel import lazy_gettext as _l
+from utils.lazystring_handler import sanitize_lazystring_recursive
 
 # Predefined map centers for each view
 view_centers = {
@@ -68,6 +69,9 @@ layout = html.Div(
     className="map-panel",
     style={"width": "100%", "height": "100%", "backgroundColor": "#121212"},
 )
+
+# Convert any LazyString objects to regular strings for safe serialization
+layout = sanitize_lazystring_recursive(layout)
 
 
 # Register callbacks

--- a/components/weak_signal_panel.py
+++ b/components/weak_signal_panel.py
@@ -3,6 +3,7 @@
 from dash import html
 import dash_bootstrap_components as dbc
 from flask_babel import lazy_gettext as _l
+from utils.lazystring_handler import sanitize_lazystring_recursive
 
 
 # Example signal card
@@ -101,3 +102,6 @@ layout = html.Div(
     ],
     className="weak-signal-panel",
 )
+
+# Ensure no LazyString objects remain in the layout
+layout = sanitize_lazystring_recursive(layout)


### PR DESCRIPTION
## Summary
- sanitize LazyString objects in major component layouts

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'dash')*

------
https://chatgpt.com/codex/tasks/task_e_6852c92427ac83209c8a8c3362d1354d