### PR TITLE
Implement custom JSON provider

### DIFF
--- a/utils/__init__.py
+++ b/utils/__init__.py
@@ -1,0 +1,5 @@
+"""Utility helpers for Yōsai Intel Dashboard."""
+
+from .json_encoder import YosaiJSONProvider
+
+__all__ = ["YosaiJSONProvider"]

--- a/utils/json_encoder.py
+++ b/utils/json_encoder.py
@@ -1,0 +1,14 @@
+from flask.json.provider import DefaultJSONProvider
+from flask_babel import LazyString
+
+
+class YosaiJSONProvider(DefaultJSONProvider):
+    """JSON provider that safely serializes LazyString objects."""
+
+    def default(self, obj):
+        if isinstance(obj, LazyString):
+            return str(obj)
+        return super().default(obj)
+
+
+__all__ = ["YosaiJSONProvider"]


### PR DESCRIPTION
## Summary
- implement `YosaiJSONProvider` to handle `LazyString` objects
- expose `YosaiJSONProvider` in utils

## Testing
- `black . --check` *(fails: many files would be reformatted)*
- `flake8 .` *(fails: command not found)*
- `mypy .` *(fails: found 1 error and stopped)
- `python tests/test_modular_system.py` *(fails: ModuleNotFoundError: pandas)*
- `python tests/test_dashboard.py` *(fails: ModuleNotFoundError: pandas)*
- `pytest` *(fails: ModuleNotFoundError: dash)*

------
https://chatgpt.com/codex/tasks/task_e_6852ccb3b12c8320bced172b4bc55ba9