### PR TITLE
Add lazystring ping endpoint test

### DIFF
--- a/core/app_factory.py
+++ b/core/app_factory.py
@@ -8,7 +8,7 @@ import dash
 from flask_login import login_required
 from flask_wtf import CSRFProtect
 from flask import session, redirect, request
-from flask_babel import Babel
+from flask_babel import Babel, lazy_gettext
 from .auth import init_auth
 from config.yaml_config import ConfigurationManager, get_configuration_manager
 from .component_registry import ComponentRegistry
@@ -212,7 +212,17 @@ def create_application(config_path: Optional[str] = None) -> Optional[YosaiDash]
 def create_application_for_testing() -> Optional[YosaiDash]:
     """Create application instance configured for unit tests."""
     try:
-        return create_application(None)
+        app = create_application(None)
+        if app is None:
+            return None
+
+        server = app.server
+
+        @server.route("/api/ping")
+        def ping() -> Any:
+            return server.json.response({"msg": lazy_gettext("pong")})
+
+        return app
     except Exception as e:
         logger.error(f"Error creating test application: {e}")
         return None

--- a/tests/i18n/test_lazystring.py
+++ b/tests/i18n/test_lazystring.py
@@ -1,0 +1,13 @@
+import pytest
+
+from core.app_factory import create_application_for_testing
+
+@pytest.mark.i18n
+def test_lazystring_response_converted():
+    app = create_application_for_testing()
+    assert app is not None
+    server = app.server
+    with server.test_client() as client:
+        resp = client.get('/api/ping')
+        assert resp.status_code == 200
+        assert resp.get_json()['msg'] == 'pong'


### PR DESCRIPTION
## Summary
- test ping route using lazy_gettext returns pong
- implement /api/ping test helper in create_application_for_testing

## Testing
- `pytest tests/i18n/test_lazystring.py -q` *(fails: ModuleNotFoundError: No module named 'dash')*

------
https://chatgpt.com/codex/tasks/task_e_6852ccb622588320a8a51cca5d2d1d32