### PR TITLE
Fix JSON provider import

### DIFF
--- a/core/app_factory.py
+++ b/core/app_factory.py
@@ -17,6 +17,7 @@ from .layout_manager import LayoutManager
 from .callback_manager import CallbackManager
 from .service_registry import get_configured_container_with_yaml
 from .container import Container
+from utils import YosaiJSONProvider
 
 logger = logging.getLogger(__name__)
 


### PR DESCRIPTION
## Summary
- import YosaiJSONProvider in app_factory

## Testing
- `pytest -q tests/test_json_serialization_plugin.py` *(fails: ModuleNotFoundError: No module named 'dash')*

------
https://chatgpt.com/codex/tasks/task_e_6852ce9af0948320ba1b36a4f488ddf8