### PR TITLE
Add architecture documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ An AI-powered modular security intelligence dashboard for physical access contro
 
 ## 🏗️ Modular Architecture
 
-This project follows a fully modular architecture for maximum maintainability and testability:
+This project follows a fully modular architecture for maximum maintainability and testability. See [docs/architecture.md](docs/architecture.md) for an overview diagram:
 
 ```
 yosai_intel_dashboard/

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,13 @@
+# Application Architecture
+
+The dashboard is organized around a small core that wires together services and database models through a dependency injection (DI) container. The entry point is an application factory which creates the Dash/Flask app and registers all services.
+
+![Architecture Diagram](architecture.svg)
+
+1. **App Factory** – Initializes the Flask app and configures extensions.
+2. **DI Container** – Provides application-wide services and resolves dependencies.
+3. **Services** – Encapsulate business logic and rely on models for data access.
+4. **Models** – Data representations loaded from or persisted to the database.
+5. **Database** – PostgreSQL, SQLite, or a mock backend configured in `config/`.
+
+The factory builds the container, which then instantiates services. Services operate on models retrieved from the database layer. This layered approach keeps components loosely coupled and easy to test.

--- a/docs/architecture.svg
+++ b/docs/architecture.svg
@@ -1,0 +1,26 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="600" height="300" font-family="sans-serif">
+  <defs>
+    <marker id="arrow" viewBox="0 0 10 10" refX="10" refY="5" markerWidth="6" markerHeight="6" orient="auto-start-reverse">
+      <path d="M 0 0 L 10 5 L 0 10 z" fill="#333" />
+    </marker>
+  </defs>
+  <rect x="20" y="20" width="120" height="50" fill="#f0f0f0" stroke="#333" />
+  <text x="80" y="50" text-anchor="middle" font-size="14">App Factory</text>
+
+  <rect x="200" y="20" width="120" height="50" fill="#f0f0f0" stroke="#333" />
+  <text x="260" y="50" text-anchor="middle" font-size="14">DI Container</text>
+
+  <rect x="380" y="20" width="120" height="50" fill="#f0f0f0" stroke="#333" />
+  <text x="440" y="50" text-anchor="middle" font-size="14">Services</text>
+
+  <rect x="260" y="120" width="120" height="50" fill="#f0f0f0" stroke="#333" />
+  <text x="320" y="150" text-anchor="middle" font-size="14">Models</text>
+
+  <rect x="260" y="220" width="120" height="50" fill="#f0f0f0" stroke="#333" />
+  <text x="320" y="250" text-anchor="middle" font-size="14">Database</text>
+
+  <line x1="140" y1="45" x2="200" y2="45" stroke="#333" marker-end="url(#arrow)" />
+  <line x1="320" y1="45" x2="380" y2="45" stroke="#333" marker-end="url(#arrow)" />
+  <line x1="440" y1="70" x2="320" y2="120" stroke="#333" marker-end="url(#arrow)" />
+  <line x1="320" y1="170" x2="320" y2="220" stroke="#333" marker-end="url(#arrow)" />
+</svg>


### PR DESCRIPTION
## Summary
- add architecture diagram and overview
- link the architecture doc from the README

## Testing
- `black . --check` *(fails: would reformat many files)*
- `flake8 .` *(fails: command not found)*
- `mypy .` *(fails: found 1 error in 1 file)*
- `python tests/test_modular_system.py` *(fails: ModuleNotFoundError: No module named 'pandas')*
- `pytest` *(fails: ModuleNotFoundError: No module named 'dash')*

------
https://chatgpt.com/codex/tasks/task_e_6853b249aec08320b7cd1766e0c3f1c8