### PR TITLE
Add analytics dependencies

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -58,3 +58,10 @@ cryptography>=41.0.3
 flask-wtf>=1.2.1
 Flask-Babel>=4.0.0
 babel>=2.14.0
+# Analytics Engine Dependencies
+scikit-learn==1.3.0
+asyncio-core==3.4.8
+marshmallow==3.20.1
+prometheus-client==0.17.1
+pydantic==2.4.2
+python-dateutil==2.8.2


### PR DESCRIPTION
## Summary
- extend dependencies with analytics engine packages in requirements

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'dash')*

------
https://chatgpt.com/codex/tasks/task_e_6853b5740e1483208d7f023a351e87cd