### PR TITLE
Fix Dash run method

### DIFF
--- a/app.py
+++ b/app.py
@@ -41,5 +41,5 @@ def create_safe_app():
 
 if __name__ == "__main__":
     app = create_safe_app()
-    app.run_server(debug=True, host="0.0.0.0", port=8050)
+    app.run(debug=True, host="0.0.0.0", port=8050)
 


### PR DESCRIPTION
## Summary
- update `app.run_server` call per Dash API deprecation

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'dash')*

------
https://chatgpt.com/codex/tasks/task_e_6853c32f2e608320a3aa1b6bfa0ae92a