### PR TITLE
Update babel dependencies

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -56,8 +56,9 @@ flask-login>=0.6.2
 python-jose>=3.3.0
 cryptography>=41.0.3
 flask-wtf>=1.2.1
-Flask-Babel>=4.0.0
-babel>=2.14.0
+flask-babel==3.1.0
+babel==2.12.1
+pytz==2023.3
 # Analytics Engine Dependencies
 scikit-learn==1.3.0
 asyncio-core==3.4.8


### PR DESCRIPTION
## Summary
- pin babel at 2.12.1
- pin flask-babel at 3.1.0
- add pytz 2023.3

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'dash')*

------
https://chatgpt.com/codex/tasks/task_e_6853c9e0fd388320a86aaeb2851212d9