### PR TITLE
Fix LazyString JSON serialization

### DIFF
--- a/core/app_factory.py
+++ b/core/app_factory.py
@@ -15,8 +15,10 @@ try:
 
     # Convert LazyString objects to regular strings for Dash compatibility
     def lazy_gettext(text: str) -> str:
+        """Get translated text as regular string (not LazyString)"""
         result = _lazy_gettext(text)
-        return str(result) if hasattr(result, "__str__") else text
+        # Force conversion to string to prevent JSON serialization issues
+        return str(result)
 except ImportError:  # pragma: no cover - Flask-Babel optional
     BABEL_AVAILABLE = False
 

--- a/core/json_serialization_plugin.py
+++ b/core/json_serialization_plugin.py
@@ -51,9 +51,20 @@ class YosaiJSONEncoder(json.JSONEncoder):
     def default(self, obj: Any) -> Any:
         """Handle all Yōsai-specific types with proper error boundaries"""
         
-        # Handle Flask-Babel LazyString objects
-        if (LazyString is not None and isinstance(obj, LazyString)) or 'LazyString' in obj.__class__.__name__:
+        # Handle Flask-Babel LazyString objects - CRITICAL FIX
+        if LazyString is not None and isinstance(obj, LazyString):
             return str(obj)
+
+        # Fallback LazyString detection for any Babel lazy objects
+        if hasattr(obj, '__class__') and 'LazyString' in str(obj.__class__):
+            return str(obj)
+
+        # Handle Babel lazy evaluation objects
+        if hasattr(obj, '_func') and hasattr(obj, '_args'):
+            try:
+                return str(obj)
+            except Exception:
+                return f"LazyString: {repr(obj)}"
 
         # Handle pandas DataFrames
         if isinstance(obj, pd.DataFrame):

--- a/utils/callback_decorators.py
+++ b/utils/callback_decorators.py
@@ -1,64 +1,177 @@
-# utils/callback_decorators.py
+#!/usr/bin/env python3
 """
 Decorators for Dash callbacks to handle JSON serialization
 """
 
 import functools
-from typing import Callable, Any
+import json
 import logging
+from typing import Callable, Any
+import pandas as pd
+
+# Safe import for Flask-Babel LazyString
+try:
+    from flask_babel import LazyString
+    LAZYSTRING_AVAILABLE = True
+except ImportError:
+    LazyString = None
+    LAZYSTRING_AVAILABLE = False
 
 logger = logging.getLogger(__name__)
 
 
+def sanitize_for_dash(data: Any) -> Any:
+    """Sanitize data for Dash callback output - handles all JSON serialization issues"""
+
+    if data is None:
+        return None
+
+    # Handle Flask-Babel LazyString objects (most common cause of the error)
+    if LAZYSTRING_AVAILABLE and isinstance(data, LazyString):
+        return str(data)
+
+    # Handle any object that has LazyString in class name (fallback detection)
+    if hasattr(data, '__class__') and 'LazyString' in str(data.__class__):
+        return str(data)
+
+    # Handle Babel lazy evaluation objects
+    if hasattr(data, '_func') and hasattr(data, '_args'):
+        try:
+            return str(data)
+        except Exception:
+            return f"LazyString: {repr(data)}"
+
+    # Handle functions - return safe representation
+    if callable(data):
+        try:
+            from dash import html
+            return html.Div(f"Function: {getattr(data, '__name__', 'anonymous')}")
+        except ImportError:
+            return {
+                'type': 'function',
+                'name': getattr(data, '__name__', 'anonymous'),
+                'module': getattr(data, '__module__', None)
+            }
+
+    # Handle DataFrames
+    if isinstance(data, pd.DataFrame):
+        if len(data) > 100:  # Limit size
+            data = data.head(100)
+        return data.to_dict('records')
+
+    # Handle lists and tuples recursively
+    if isinstance(data, (list, tuple)):
+        return type(data)(sanitize_for_dash(item) for item in data)
+
+    # Handle dictionaries recursively
+    if isinstance(data, dict):
+        return {key: sanitize_for_dash(value) for key, value in data.items()}
+
+    # Handle Dash components with potential LazyString properties
+    if hasattr(data, 'to_plotly_json'):
+        try:
+            # Test if component is already serializable
+            json.dumps(data.to_plotly_json())
+            return data
+        except (TypeError, ValueError):
+            # Component has LazyString properties, sanitize them
+            component_dict = data.to_plotly_json()
+            return sanitize_for_dash(component_dict)
+
+    # Handle complex objects
+    if hasattr(data, '__dict__') and not isinstance(data, (str, int, float, bool)):
+        try:
+            # Test if object is already serializable
+            json.dumps(data.__dict__)
+            return data
+        except (TypeError, ValueError):
+            return {
+                'type': 'object',
+                'class': data.__class__.__name__,
+                'repr': str(data)[:200]
+            }
+
+    # Test if primitive type is serializable
+    try:
+        json.dumps(data)
+        return data
+    except (TypeError, ValueError):
+        # Return safe representation
+        return {
+            'type': type(data).__name__,
+            'repr': str(data)[:200],
+            'serializable': False
+        }
+
+
 def safe_callback(func: Callable) -> Callable:
     """Decorator to make Dash callbacks safe from JSON serialization errors"""
-    
+
     @functools.wraps(func)
     def wrapper(*args, **kwargs):
         try:
             # Execute the original callback
             result = func(*args, **kwargs)
-            
+
             # Sanitize the result for Dash
             sanitized_result = sanitize_for_dash(result)
-            
+
             return sanitized_result
-            
+
         except Exception as e:
             logger.error(f"Error in callback {func.__name__}: {e}")
-            
+
             # Return safe error representation
-            return {
-                'error': True,
-                'message': str(e),
-                'callback': func.__name__
-            }
-    
+            try:
+                from dash import html
+                return html.Div([
+                    html.H4("⚠️ Callback Error", className="text-warning"),
+                    html.P(f"Function: {func.__name__}"),
+                    html.P(f"Error: {str(e)[:100]}..."),
+                ], className="alert alert-warning")
+            except ImportError:
+                return {
+                    'error': True,
+                    'message': str(e),
+                    'callback': func.__name__
+                }
+
     return wrapper
 
 
 def analytics_callback(func: Callable) -> Callable:
     """Specialized decorator for analytics callbacks"""
-    
+
     @functools.wraps(func)
     def wrapper(*args, **kwargs):
         try:
             result = func(*args, **kwargs)
-            
+
             # Special handling for analytics data
             if isinstance(result, dict) and 'analytics' in result:
                 # Ensure analytics data is JSON serializable
                 result['analytics'] = sanitize_for_dash(result['analytics'])
-            
+
             return sanitize_for_dash(result)
-            
+
         except Exception as e:
             logger.error(f"Error in analytics callback {func.__name__}: {e}")
-            return {
-                'error': True,
-                'message': f"Analytics processing failed: {str(e)}",
-                'callback': func.__name__
-            }
-    
+            try:
+                from dash import html
+                return html.Div([
+                    html.H4("⚠️ Analytics Error", className="text-danger"),
+                    html.P(f"Function: {func.__name__}"),
+                    html.P(f"Analytics processing failed: {str(e)[:100]}..."),
+                ], className="alert alert-danger")
+            except ImportError:
+                return {
+                    'error': True,
+                    'message': f"Analytics processing failed: {str(e)}",
+                    'callback': func.__name__
+                }
+
     return wrapper
 
+
+# Export for easy importing
+__all__ = ['safe_callback', 'analytics_callback', 'sanitize_for_dash']

--- a/utils/lazystring_utils.py
+++ b/utils/lazystring_utils.py
@@ -1,0 +1,101 @@
+#!/usr/bin/env python3
+"""
+Comprehensive LazyString handling utilities
+Fixes all Flask-Babel LazyString JSON serialization issues
+"""
+
+import json
+import logging
+from typing import Any, Union
+
+logger = logging.getLogger(__name__)
+
+# Safe import for Flask-Babel
+try:
+    from flask_babel import LazyString
+    BABEL_AVAILABLE = True
+except ImportError:  # pragma: no cover - optional dependency
+    LazyString = None  # type: ignore
+    BABEL_AVAILABLE = False
+
+
+def is_lazy_string(obj: Any) -> bool:
+    """Check if object is any type of LazyString"""
+    if BABEL_AVAILABLE and isinstance(obj, LazyString):
+        return True
+
+    # Check by class name for different Babel versions
+    class_name = str(obj.__class__)
+    if 'LazyString' in class_name or 'lazy_string' in class_name.lower():
+        return True
+
+    # Check for lazy evaluation pattern
+    if hasattr(obj, '_func') and hasattr(obj, '_args'):
+        return True
+
+    return False
+
+
+def force_string_conversion(obj: Any) -> str:
+    """Force conversion of any lazy string object to regular string"""
+    if is_lazy_string(obj):
+        try:
+            return str(obj)
+        except Exception as e:  # pragma: no cover - extreme edge case
+            logger.warning(f"Failed to convert LazyString to string: {e}")
+            return f"<LazyString conversion failed: {repr(obj)}>"
+
+    return str(obj)
+
+
+def sanitize_json_data(data: Any) -> Any:
+    """Recursively sanitize data to remove all LazyString objects"""
+    if is_lazy_string(data):
+        return force_string_conversion(data)
+
+    if isinstance(data, dict):
+        return {key: sanitize_json_data(value) for key, value in data.items()}
+
+    if isinstance(data, (list, tuple)):
+        return type(data)(sanitize_json_data(item) for item in data)
+
+    # Test if object is JSON serializable
+    try:
+        json.dumps(data)
+        return data
+    except (TypeError, ValueError):
+        # If not serializable and has LazyString attributes, sanitize them
+        if hasattr(data, '__dict__'):
+            sanitized_dict = {}
+            for key, value in data.__dict__.items():
+                if is_lazy_string(value):
+                    sanitized_dict[key] = force_string_conversion(value)
+                else:
+                    sanitized_dict[key] = sanitize_json_data(value)
+
+            # Return sanitized representation
+            return {
+                'type': data.__class__.__name__,
+                'attributes': sanitized_dict
+            }
+
+        # Fallback to string representation
+        return str(data)
+
+
+def test_json_serialization(data: Any) -> Union[str, None]:
+    """Test if data can be JSON serialized, return error message if not"""
+    try:
+        json.dumps(data)
+        return None  # Success
+    except Exception as e:
+        return str(e)
+
+
+# Export for easy importing
+__all__ = [
+    'is_lazy_string',
+    'force_string_conversion',
+    'sanitize_json_data',
+    'test_json_serialization'
+]


### PR DESCRIPTION
## Summary
- add comprehensive callback decorators and sanitize LazyString handling
- improve LazyString detection in JSON plugin and handlers
- ensure lazy gettext returns string
- add lazystring utilities module

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'dash')*

------
https://chatgpt.com/codex/tasks/task_e_6853db47f44c8320b2c6ea87bfe0ae48