### PR TITLE
Fix LazyString serialization bugs

### DIFF
--- a/core/app_factory.py
+++ b/core/app_factory.py
@@ -116,9 +116,13 @@ class DashAppFactory:
             app.title = config_manager.app_config.title
             server = app.server
 
-            # CRITICAL: Set custom JSON provider to handle LazyString objects
-            server.json = YosaiJSONProvider(server)
-            logger.info("✅ Custom JSON provider set up for LazyString handling")
+            # Register custom JSON provider to handle LazyString objects
+            try:
+                from utils.json_encoder import YosaiJSONProvider
+                app.server.json = YosaiJSONProvider(app.server)
+                logger.info("✅ Custom JSON provider set for LazyString handling")
+            except Exception as e:
+                logger.warning(f"Failed to set custom JSON provider: {e}")
 
             app._config_manager = config_manager
             app._yosai_container = container

--- a/utils/json_encoder.py
+++ b/utils/json_encoder.py
@@ -1,73 +1,32 @@
-#!/usr/bin/env python3
-"""
-Flask JSON Provider that handles LazyString objects
-This fixes the core Dash JSON serialization issue
-"""
-
 import json
-import logging
-from typing import Any
 from flask.json.provider import DefaultJSONProvider
-
-# Safe import for Flask-Babel LazyString
-try:
-    from flask_babel import LazyString
-    BABEL_AVAILABLE = True
-except ImportError:
-    LazyString = None  # type: ignore
-    BABEL_AVAILABLE = False
-
-logger = logging.getLogger(__name__)
-
-
-class LazyStringSafeJSONEncoder(json.JSONEncoder):
-    """JSON encoder that specifically handles LazyString objects"""
-
-    def default(self, obj: Any) -> Any:
-        # Handle Flask-Babel LazyString objects - CRITICAL FIX
-        if BABEL_AVAILABLE and isinstance(obj, LazyString):
-            return str(obj)
-
-        # Handle any object with LazyString in class name (fallback)
-        if hasattr(obj, '__class__') and 'LazyString' in str(obj.__class__):
-            return str(obj)
-
-        # Handle Babel lazy evaluation objects
-        if hasattr(obj, '_func') and hasattr(obj, '_args'):
-            try:
-                return str(obj)
-            except Exception:
-                return f"LazyString: {repr(obj)}"
-
-        # Handle callables
-        if callable(obj):
-            return {
-                'type': 'function',
-                'name': getattr(obj, '__name__', 'anonymous')
-            }
-
-        # Let the parent encoder handle it
-        return super().default(obj)
+from .json_serializer import YosaiJSONEncoder
 
 
 class YosaiJSONProvider(DefaultJSONProvider):
-    """Custom JSON provider that handles LazyString and other Yōsai types"""
+    """Custom JSON provider using YosaiJSONEncoder for serialization."""
 
-    def dumps(self, obj: Any, **kwargs) -> str:
-        """Dump object to JSON string using LazyString-safe encoder"""
-        kwargs.setdefault("cls", LazyStringSafeJSONEncoder)
+    def dumps(self, obj, **kwargs):
+        kwargs.setdefault("cls", YosaiJSONEncoder)
         kwargs.setdefault("ensure_ascii", False)
         try:
             return json.dumps(obj, **kwargs)
         except Exception as e:
+            # Fallback for LazyString serialization errors
+            import logging
+            logger = logging.getLogger(__name__)
             logger.error(f"JSON serialization failed: {e}")
-            # Return safe error representation
+
+            # Emergency LazyString handling
+            if hasattr(obj, '__class__') and 'LazyString' in str(obj.__class__):
+                return json.dumps(str(obj))
+
             return json.dumps({
                 'error': 'JSON serialization failed',
                 'message': str(e),
-                'type': type(obj).__name__ if hasattr(obj, '__class__') else 'unknown'
+                'type': type(obj).__name__
             })
 
-    def loads(self, s: str, **kwargs) -> Any:
-        """Load JSON string to object"""
+    def loads(self, s, **kwargs):
         return json.loads(s, **kwargs)
+


### PR DESCRIPTION
## Summary
- improve JSON serializer to safely handle `LazyString`
- use new `YosaiJSONProvider` for Flask JSON
- register custom provider in app factory with fallback
- enhance recursive lazy string sanitization
- patch `json.dumps` at startup for LazyString safety

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'dash')*

------
https://chatgpt.com/codex/tasks/task_e_6853e1fbcf288320ad5e7c5795d7553c