### PR TITLE
Enable JSON plugin usage

### DIFF
--- a/pages/deep_analytics.py
+++ b/pages/deep_analytics.py
@@ -173,11 +173,17 @@ def register_analytics_callbacks(app, container=None):
                     if not valid:
                         continue
 
-                    # Store processed data
+                    # Store processed data using JSON plugin if available
+                    if hasattr(app, "_yosai_json_plugin"):
+                        serializer = app._yosai_json_plugin.serialization_service
+                        sanitized_df = serializer.sanitize_for_transport(df)
+                    else:
+                        sanitized_df = df.to_dict("records")
+
                     all_data.append(
                         {
                             "filename": filename,
-                            "data": df.to_dict("records"),
+                            "data": sanitized_df,
                             "columns": list(df.columns),
                             "rows": len(df),
                             "suggestions": suggestions,


### PR DESCRIPTION
## Summary
- load JSON serialization plugin in `app.py`
- sanitize uploaded DataFrames with the plugin in `process_uploaded_files`

## Testing
- `python3 -m pytest -q tests/test_json_serialization_plugin.py` *(fails: ModuleNotFoundError: No module named 'dash')*

------
https://chatgpt.com/codex/tasks/task_e_6853ee25bc7483209ba91f052ebf9e5d