### PR TITLE
Fix Pylance JSON provider errors

### DIFF
--- a/app.py
+++ b/app.py
@@ -65,6 +65,7 @@ def create_app_with_json_plugin() -> Optional[Any]:
 
         # Step 2: **ACTUALLY LOAD THE JSON PLUGIN**
         from core.json_serialization_plugin import JsonSerializationPlugin
+        from core.lazystring_json_provider import LazyStringSafeJSONProvider
         from core.container import Container
 
         # Create DI container
@@ -88,9 +89,11 @@ def create_app_with_json_plugin() -> Optional[Any]:
             json_plugin.configure(plugin_config)
             json_plugin.start()
 
-            # **CRITICAL: Set the plugin's encoder as Flask's JSON provider**
-            app.server.json_encoder = json_plugin.serialization_service.encoder.__class__
-            app.server.json = json_plugin.serialization_service
+            # Use custom JSON provider backed by the plugin
+            app.server.json_provider_class = LazyStringSafeJSONProvider
+            app.server.json = LazyStringSafeJSONProvider(
+                app.server, json_plugin.serialization_service
+            )
 
             # Store plugin in app for callbacks to use
             app._yosai_json_plugin = json_plugin

--- a/core/json_serialization_plugin.py
+++ b/core/json_serialization_plugin.py
@@ -32,21 +32,31 @@ try:
         ErrorCategory,
         ErrorSeverity,
     )
-except ImportError:
-    # Create minimal fallbacks if error handling not available
+except ImportError:  # pragma: no cover - fallback for missing module
     from enum import Enum
     from typing import Any, Callable, TypeVar
 
     F = TypeVar("F", bound=Callable[..., Any])
 
     class ErrorCategory(str, Enum):
+        DATABASE = "database"
+        FILE_PROCESSING = "file_processing"
+        AUTHENTICATION = "authentication"
+        ANALYTICS = "analytics"
         CONFIGURATION = "configuration"
+        EXTERNAL_API = "external_api"
+        USER_INPUT = "user_input"
 
     class ErrorSeverity(str, Enum):
+        LOW = "low"
         MEDIUM = "medium"
+        HIGH = "high"
+        CRITICAL = "critical"
 
     def with_error_handling(
-        category: ErrorCategory, severity: ErrorSeverity
+        category: ErrorCategory = ErrorCategory.ANALYTICS,
+        severity: ErrorSeverity = ErrorSeverity.MEDIUM,
+        reraise: bool = False,
     ) -> Callable[[F], F]:
         def decorator(func: F) -> F:
             return func
@@ -56,19 +66,24 @@ except ImportError:
 # Import performance monitoring safely  
 try:
     from core.performance import measure_performance, MetricType
-except ImportError:
-    # Create minimal fallbacks if performance monitoring not available
+except ImportError:  # pragma: no cover - fallback for missing module
     from typing import Callable, TypeVar
 
     F = TypeVar("F", bound=Callable[..., Any])
 
-    def measure_performance(name: str, metric_type: "MetricType") -> Callable[[F], F]:
+    def measure_performance(
+        name: str | None = None,
+        metric_type: "MetricType" = MetricType.EXECUTION_TIME,
+        threshold: float | None = None,
+        tags: dict[str, str] | None = None,
+    ) -> Callable[[F], F]:
         def decorator(func: F) -> F:
             return func
 
         return decorator
 
     class MetricType(str, Enum):
+        EXECUTION_TIME = "execution_time"
         SERIALIZATION = "serialization"
         CALLBACK = "callback"
 

--- a/core/lazystring_json_provider.py
+++ b/core/lazystring_json_provider.py
@@ -1,0 +1,25 @@
+from __future__ import annotations
+
+"""Custom JSON provider using JsonSerializationService."""
+
+import json
+from typing import Any
+
+from flask import Flask
+from flask.json.provider import DefaultJSONProvider
+
+from .json_serialization_plugin import JsonSerializationService
+
+
+class LazyStringSafeJSONProvider(DefaultJSONProvider):
+    """JSON provider that delegates serialization to JsonSerializationService."""
+
+    def __init__(self, app: Flask, service: JsonSerializationService) -> None:
+        super().__init__(app)
+        self.service = service
+
+    def dumps(self, obj: Any, **kwargs: Any) -> str:
+        return self.service.serialize(obj)
+
+    def loads(self, s: str | bytes, **kwargs: Any) -> Any:
+        return json.loads(s)


### PR DESCRIPTION
## Summary
- implement `LazyStringSafeJSONProvider` for custom serialization
- configure Dash app to use the custom provider
- align fallback type hints in `json_serialization_plugin`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'dash')*

------
https://chatgpt.com/codex/tasks/task_e_685419b81fdc8320a7176cfb68cda2c3