### PR TITLE
Fix safe_text imports and add text utils

### DIFF
--- a/pages/deep_analytics.py
+++ b/pages/deep_analytics.py
@@ -21,7 +21,6 @@ try:
         create_data_preview,
         AnalyticsGenerator
     )
-    from utils.safe_callbacks import safe_text
     ANALYTICS_COMPONENTS_AVAILABLE = True
 except ImportError:
     ANALYTICS_COMPONENTS_AVAILABLE = False
@@ -33,6 +32,13 @@ except ImportError:
             return {}
     
     AnalyticsGenerator = FallbackAnalyticsGenerator
+
+# Import text utilities
+try:
+    from utils.text_utils import safe_text
+except ImportError:
+    def safe_text(text):
+        return str(text) if text is not None else ""
 
 logger = logging.getLogger(__name__)
 
@@ -47,7 +53,7 @@ def layout():
         dbc.Row([
             dbc.Col([
                 html.H1(
-                    safe_text("\U0001F50D Deep Analytics"), 
+                    safe_text("\U0001F50D Deep Analytics"),
                     className="text-primary mb-0"
                 ),
                 html.P(
@@ -438,7 +444,7 @@ def _create_no_data_message(data_source):
     """Create no data available message"""
     return dbc.Alert([
         html.I(className="fas fa-info-circle me-2"),
-        f"No data available from source: {data_source}",
+        f"No data available from source: {safe_text(data_source)}",
         html.Hr(),
         html.P("Please upload files using the File Upload page or select a different data source.", className="mb-0")
     ], color="info")
@@ -448,7 +454,7 @@ def _create_error_display(error_message):
     """Create error display"""
     return dbc.Alert([
         html.I(className="fas fa-exclamation-triangle me-2"),
-        f"Error generating analytics: {error_message}"
+        f"Error generating analytics: {safe_text(error_message)}"
     ], color="danger")
 
 

--- a/pages/file_upload.py
+++ b/pages/file_upload.py
@@ -17,11 +17,21 @@ except ImportError:
 try:
     from components.analytics.file_uploader import create_file_uploader
     from components.analytics.file_processing import FileProcessor
-    from utils.safe_callbacks import safe_text
     COMPONENTS_AVAILABLE = True
 except ImportError:
     COMPONENTS_AVAILABLE = False
     FileProcessor = None
+
+# Import text utilities
+try:
+    from utils.text_utils import safe_text, format_file_size
+except ImportError:
+    # Fallback safe_text function
+    def safe_text(text):
+        return str(text) if text is not None else ""
+
+    def format_file_size(size_bytes):
+        return f"{size_bytes} bytes"
 
 logger = logging.getLogger(__name__)
 
@@ -183,7 +193,7 @@ def register_file_upload_callbacks(app, container=None):
 def _create_success_alert(message: str) -> dbc.Alert:
     """Create a success alert message"""
     return dbc.Alert(
-        [html.I(className="fas fa-check-circle me-2"), message],
+        [html.I(className="fas fa-check-circle me-2"), safe_text(message)],
         color="success",
         className="mb-2",
     )
@@ -192,7 +202,7 @@ def _create_success_alert(message: str) -> dbc.Alert:
 def _create_warning_alert(message: str) -> dbc.Alert:
     """Create a warning alert message"""
     return dbc.Alert(
-        [html.I(className="fas fa-exclamation-triangle me-2"), message],
+        [html.I(className="fas fa-exclamation-triangle me-2"), safe_text(message)],
         color="warning",
         className="mb-2",
     )
@@ -201,7 +211,7 @@ def _create_warning_alert(message: str) -> dbc.Alert:
 def _create_error_alert(message: str) -> dbc.Alert:
     """Create an error alert message"""
     return dbc.Alert(
-        [html.I(className="fas fa-times-circle me-2"), message],
+        [html.I(className="fas fa-times-circle me-2"), safe_text(message)],
         color="danger",
         className="mb-2",
     )
@@ -210,7 +220,7 @@ def _create_error_alert(message: str) -> dbc.Alert:
 def _create_info_alert(message: str) -> dbc.Alert:
     """Create an info alert message"""
     return dbc.Alert(
-        [html.I(className="fas fa-info-circle me-2"), message],
+        [html.I(className="fas fa-info-circle me-2"), safe_text(message)],
         color="info",
         className="mb-2",
     )
@@ -218,9 +228,11 @@ def _create_info_alert(message: str) -> dbc.Alert:
 
 def _create_file_info_card(df, filename: str) -> dbc.Card:
     """Create detailed file information card"""
+    memory_usage = df.memory_usage(deep=True).sum()
+
     return dbc.Card([
         dbc.CardHeader([
-            html.H5(f"\U0001F4CA {filename}", className="mb-0"),
+            html.H5(f"\U0001F4CA {safe_text(filename)}", className="mb-0"),
         ]),
         dbc.CardBody([
             dbc.Row([
@@ -229,14 +241,14 @@ def _create_file_info_card(df, filename: str) -> dbc.Card:
                     html.P(f"Columns: {len(df.columns)}", className="mb-1"),
                 ], width=6),
                 dbc.Col([
-                    html.P(f"Memory: {df.memory_usage(deep=True).sum() / 1024:.1f} KB", className="mb-1"),
+                    html.P(f"Memory: {format_file_size(memory_usage)}", className="mb-1"),
                     html.P(f"Null values: {df.isnull().sum().sum()}", className="mb-1"),
                 ], width=6),
             ]),
             html.Hr(),
             html.H6("Column Types:", className="mt-2"),
             html.Div([
-                dbc.Badge(f"{col}: {dtype}", color="secondary", className="me-1 mb-1")
+                dbc.Badge(f"{safe_text(col)}: {safe_text(dtype)}", color="secondary", className="me-1 mb-1")
                 for col, dtype in df.dtypes.items()
             ]),
         ])
@@ -247,7 +259,7 @@ def _create_file_management_card(file_id: str, filename: str, df) -> dbc.Card:
     """Create file management card with actions"""
     return dbc.Card([
         dbc.CardHeader([
-            html.H6(f"\U0001F527 Manage {filename}", className="mb-0"),
+            html.H6(f"\U0001F527 Manage {safe_text(filename)}", className="mb-0"),
         ]),
         dbc.CardBody([
             dbc.ButtonGroup([

--- a/tests/test_text_utils.py
+++ b/tests/test_text_utils.py
@@ -1,0 +1,32 @@
+"""
+Tests for text utilities
+"""
+import pytest
+from utils.text_utils import safe_text, format_file_size, truncate_text
+
+
+def test_safe_text():
+    """Test safe_text function"""
+    assert safe_text("hello") == "hello"
+    assert safe_text(123) == "123"
+    assert safe_text(None) == ""
+    assert safe_text("") == ""
+
+
+def test_format_file_size():
+    """Test file size formatting"""
+    assert format_file_size(0) == "0 B"
+    assert format_file_size(1024) == "1.0 KB"
+    assert format_file_size(1024 * 1024) == "1.0 MB"
+    assert format_file_size(500) == "500 B"
+
+
+def test_truncate_text():
+    """Test text truncation"""
+    assert truncate_text("hello", 10) == "hello"
+    assert truncate_text("hello world", 5) == "he..."
+    assert truncate_text("hello world", 11) == "hello world"
+
+
+if __name__ == "__main__":
+    pytest.main([__file__])

--- a/utils/text_utils.py
+++ b/utils/text_utils.py
@@ -1,0 +1,50 @@
+"""
+Text utilities for safe text handling
+"""
+from typing import Any, Union
+
+
+def safe_text(text: Union[str, Any]) -> str:
+    """Return text safely, handling any babel objects or non-string types"""
+    if text is None:
+        return ""
+
+    # Handle different types safely
+    if hasattr(text, '__str__'):
+        return str(text)
+
+    # Fallback for any other type
+    return repr(text)
+
+
+def sanitize_text_for_dash(text: Union[str, Any]) -> str:
+    """Sanitize text specifically for Dash components"""
+    safe_str = safe_text(text)
+    safe_str = safe_str.replace('\x00', '')  # Remove null bytes
+    safe_str = safe_str.replace('\ufeff', '')  # Remove BOM
+    return safe_str
+
+
+def format_file_size(size_bytes: int) -> str:
+    """Format file size in human readable format"""
+    if size_bytes == 0:
+        return "0 B"
+
+    size_names = ["B", "KB", "MB", "GB", "TB"]
+    i = 0
+    while size_bytes >= 1024 and i < len(size_names) - 1:
+        size_bytes /= 1024.0
+        i += 1
+
+    return f"{size_bytes:.1f} {size_names[i]}"
+
+
+def truncate_text(text: str, max_length: int = 100, suffix: str = "...") -> str:
+    """Truncate text to specified length"""
+    if len(text) <= max_length:
+        return text
+
+    return text[:max_length - len(suffix)] + suffix
+
+
+__all__ = ["safe_text", "sanitize_text_for_dash", "format_file_size", "truncate_text"]


### PR DESCRIPTION
## Summary
- add safe text utilities module
- update File Upload and Deep Analytics pages to use safe_text
- export file upload page loader in pages
- add unit tests for text utils

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'dash')*

------
https://chatgpt.com/codex/tasks/task_e_6854ab6358dc83208b0f87beff703c5d