### PR TITLE
Refactor navbar to plugin

### DIFF
--- a/assets/dashboard.css
+++ b/assets/dashboard.css
@@ -284,3 +284,222 @@ html, body, #root, .dash-app {
 .signal-card-header.signal-low {
   border-left: 4px solid var(--color-success);
 }
+
+/* ========================================
+   NAVBAR PLUGIN STYLES - Grid Layout with Icons
+   ======================================== */
+.navbar__main {
+  background-color: var(--color-primary) !important;
+  border-bottom: 2px solid var(--color-accent);
+  min-height: 70px;
+}
+
+.navbar__container {
+  padding: 0;
+}
+
+.navbar__grid-container {
+  display: grid;
+  grid-template-columns: 1fr 2fr 1fr;
+  align-items: center;
+  width: 100%;
+  min-height: 60px;
+  gap: 1rem;
+}
+
+/* Left Column - Logo */
+.navbar__left-column {
+  display: flex;
+  align-items: center;
+  justify-content: flex-start;
+  padding-left: 1rem;
+}
+
+.navbar__logo {
+  height: 45px;
+  filter: brightness(1.1);
+  transition: all 0.3s ease;
+}
+
+.navbar__logo-link:hover .navbar__logo {
+  filter: brightness(1.3);
+  transform: translateY(-1px);
+}
+
+/* Center Column - Main Panel Info */
+.navbar__center-column {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  text-align: center;
+}
+
+.navbar__main-label {
+  color: var(--color-text-secondary);
+  font-size: 0.875rem;
+  font-weight: 600;
+  margin-bottom: 0.25rem;
+  letter-spacing: 0.025em;
+}
+
+.navbar__status-bar {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex-wrap: wrap;
+}
+
+.navbar__user-info {
+  color: var(--color-text-tertiary);
+  font-size: 0.75rem;
+  font-weight: 500;
+}
+
+.navbar__live-time {
+  color: var(--color-text-tertiary);
+  font-size: 0.75rem;
+  font-weight: 500;
+}
+
+.status-indicator {
+  font-size: 0.75rem;
+  margin-right: 0.25rem;
+  animation: pulse 2s infinite;
+}
+
+@keyframes pulse {
+  0%, 100% { opacity: 1; }
+  50% { opacity: 0.7; }
+}
+
+/* Right Column - Navigation Icons */
+.navbar__right-column {
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  padding-right: 1rem;
+}
+
+.navbar__icons-container {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  margin-right: 1rem;
+}
+
+.navbar__nav-link {
+  display: inline-block;
+  text-decoration: none;
+  transition: all 0.3s ease;
+}
+
+.navbar__icon {
+  width: 24px;
+  height: 24px;
+  filter: brightness(0.9);
+  transition: all 0.3s ease;
+}
+
+.navbar__nav-link:hover {
+  transform: translateY(-2px);
+  text-decoration: none;
+}
+
+.navbar__nav-link:hover .navbar__icon {
+  filter: brightness(1.25) saturate(1.2);
+  transform: scale(1.1);
+}
+
+/* Language Toggle */
+.navbar__language-toggle {
+  color: var(--color-text-tertiary);
+  font-size: 0.75rem;
+  font-weight: 500;
+  cursor: pointer;
+  user-select: none;
+  transition: color 0.3s ease;
+}
+
+.navbar__language-toggle:hover {
+  color: var(--color-text-primary);
+}
+
+.navbar__lang-option {
+  transition: color 0.3s ease;
+  cursor: pointer;
+  padding: 0.25rem;
+}
+
+.navbar__lang-option:hover {
+  color: var(--color-accent);
+}
+
+.navbar__lang-active {
+  color: var(--color-accent);
+  font-weight: 600;
+}
+
+.navbar__lang-separator {
+  color: #4A5568;
+  margin: 0 0.25rem;
+}
+
+/* Mobile Responsiveness */
+@media (max-width: 768px) {
+  .navbar__grid-container {
+    grid-template-columns: 1fr;
+    grid-template-rows: auto auto auto;
+    gap: 0.5rem;
+    text-align: center;
+  }
+  
+  .navbar__left-column,
+  .navbar__center-column,
+  .navbar__right-column {
+    justify-content: center;
+    padding: 0.5rem;
+  }
+  
+  .navbar__icons-container {
+    gap: 1rem;
+    margin-right: 0;
+  }
+  
+  .navbar__icon {
+    width: 28px;
+    height: 28px;
+  }
+  
+  .navbar__main-label {
+    font-size: 0.8rem;
+  }
+  
+  .navbar__user-info,
+  .navbar__live-time {
+    font-size: 0.7rem;
+  }
+}
+
+@media (max-width: 480px) {
+  .navbar__icons-container {
+    display: grid;
+    grid-template-columns: repeat(3, 1fr);
+    gap: 1rem;
+    width: 100%;
+    max-width: 200px;
+  }
+  
+  .navbar__language-toggle {
+    margin-top: 0.5rem;
+  }
+}
+
+/* Fallback styles */
+.navbar__fallback {
+  background-color: var(--color-critical);
+  color: white;
+  padding: 1rem;
+  text-align: center;
+  font-weight: bold;
+}

--- a/components/navbar.py
+++ b/components/navbar.py
@@ -1,10 +1,32 @@
-"""Navbar component wrapper."""
-from dashboard.layout.navbar import create_navbar_layout, layout, register_navbar_callbacks
+"""Navbar component wrapper - Plugin integration."""
 
-# Expose simplified function name
-
-def create_navbar():
-    return create_navbar_layout()
+try:
+    from dashboard.layout.navbar import create_plugin, create_navbar_layout, register_navbar_callbacks
+    
+    # Create plugin instance
+    _navbar_plugin = create_plugin()
+    
+    def create_navbar():
+        """Create navbar using plugin"""
+        return _navbar_plugin.create_navbar_layout()
+    
+    # Export plugin functions
+    layout = create_navbar_layout
+    
+except ImportError as e:
+    import logging
+    logger = logging.getLogger(__name__)
+    logger.error(f"Failed to import navbar plugin: {e}")
+    
+    def create_navbar():
+        return "Navbar plugin unavailable"
+    
+    def create_navbar_layout():
+        return "Navbar plugin unavailable"
+    
+    def register_navbar_callbacks(app):
+        pass
+    
+    layout = create_navbar_layout
 
 __all__ = ["create_navbar", "layout", "register_navbar_callbacks"]
-

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -38,3 +38,16 @@ plugins:
     compress_large_objects: true
     fallback_to_repr: true
     auto_wrap_callbacks: true
+
+  navbar:
+    enabled: true
+navbar:
+  location_name: "Tokyo HQ"
+  zone_name: "East Wing"
+  user_info: "HQ Tower – East Wing"
+  logo_path: "/assets/yosai_logo_name_white.png"
+  logo_height: "45px"
+  enable_language_toggle: true
+  enable_live_time: true
+  icons_base_path: "/assets/navbar_icons"
+

--- a/dashboard/layout/navbar.py
+++ b/dashboard/layout/navbar.py
@@ -1,12 +1,18 @@
-# components/navbar.py - FIXED: Type-safe navbar
 """
-Navigation bar component with complete type safety
+Navbar Plugin - Grid layout with icons and dynamic content
+Implements PluginProtocol for the Yōsai Intel Dashboard
 """
 
 import datetime
-from typing import TYPE_CHECKING
+import logging
+from typing import TYPE_CHECKING, Dict, Any
+from dataclasses import dataclass
+
 from flask_babel import lazy_gettext as _l
+from core.plugins.protocols import PluginProtocol, CallbackPluginProtocol, PluginMetadata, PluginPriority
 from core.plugins.decorators import safe_callback
+
+logger = logging.getLogger(__name__)
 
 if TYPE_CHECKING:
     import dash_bootstrap_components as dbc
@@ -15,178 +21,310 @@ if TYPE_CHECKING:
 try:
     import dash_bootstrap_components as dbc
     from dash import html, dcc, callback, Output, Input
-
     DASH_AVAILABLE = True
 except ImportError:
-    print("Warning: Dash components not available")
+    logger.warning("Dash components not available")
     DASH_AVAILABLE = False
-    # Create fallbacks
-    dbc = None
-    html = None
-    dcc = None
-    callback = None
-    Output = None
-    Input = None
+    dbc = html = dcc = callback = Output = Input = None
 
 
-def create_navbar_layout():
-    """Create navbar layout with fallback"""
-    if not DASH_AVAILABLE:
-        return None
+@dataclass
+class NavbarConfig:
+    """Navbar plugin configuration"""
+    location_name: str = "Tokyo HQ"
+    zone_name: str = "East Wing"
+    user_info: str = "HQ Tower – East Wing"
+    logo_path: str = "/assets/yosai_logo_name_white.png"
+    logo_height: str = "45px"
+    enable_language_toggle: bool = True
+    enable_live_time: bool = True
+    icons_base_path: str = "/assets/navbar_icons"
 
-    try:
-        return dbc.Navbar(
-            [
-                dbc.Container(
-                    [
-                        dcc.Location(id="url-i18n"),
-                        # Logo
-                        dbc.Row(
-                            [
-                                dbc.Col(
-                                    [
-                                        html.Img(
-                                            src="/assets/yosai_logo_name_white.png",
-                                            height="40px",
-                                            className="navbar__logo",
-                                        )
-                                    ],
-                                    width="auto",
-                                )
-                            ],
-                            align="center",
-                        ),
-                        # Center content
-                        dbc.Row(
-                            [
-                                dbc.Col(
-                                    [
-                                        html.Div(
-                                            [
-                                                html.H5(
-                                                    _l("Main Panel"),
-                                                    className="navbar__title text-primary",
+
+class NavbarPlugin(CallbackPluginProtocol):
+    """
+    Navbar Plugin with responsive grid layout, icons, and dynamic content
+    """
+    
+    def __init__(self):
+        self.config = NavbarConfig()
+        self._app = None
+        self._container = None
+        self._status = {"healthy": True, "errors": []}
+        
+    @property
+    def metadata(self) -> PluginMetadata:
+        return PluginMetadata(
+            name="navbar",
+            version="2.0.0",
+            description="Responsive navbar with grid layout and icon navigation",
+            author="Yōsai Intel Team",
+            priority=PluginPriority.CRITICAL,
+            dependencies=[],
+            config_section="navbar",
+            enabled_by_default=True
+        )
+    
+    def load(self, container: Any, config: Dict[str, Any]) -> bool:
+        """Load navbar plugin with configuration"""
+        try:
+            self._container = container
+            
+            # Update config from provided settings
+            navbar_config = config.get("navbar", {})
+            if navbar_config:
+                for key, value in navbar_config.items():
+                    if hasattr(self.config, key):
+                        setattr(self.config, key, value)
+            
+            # Register navbar layout service
+            container.register('navbar_layout', self.create_navbar_layout)
+            container.register('navbar_plugin', self)
+            
+            logger.info("Navbar plugin loaded successfully")
+            return True
+            
+        except Exception as e:
+            logger.error(f"Failed to load navbar plugin: {e}")
+            self._status["errors"].append(str(e))
+            return False
+    
+    def configure(self, config: Dict[str, Any]) -> bool:
+        """Configure navbar plugin"""
+        try:
+            navbar_settings = config.get("navbar", {})
+            for key, value in navbar_settings.items():
+                if hasattr(self.config, key):
+                    setattr(self.config, key, value)
+            return True
+        except Exception as e:
+            logger.error(f"Failed to configure navbar plugin: {e}")
+            return False
+    
+    def start(self) -> bool:
+        """Start navbar plugin"""
+        return True
+    
+    def stop(self) -> bool:
+        """Stop navbar plugin"""
+        return True
+    
+    def health_check(self) -> Dict[str, Any]:
+        """Return navbar plugin health status"""
+        return {
+            "healthy": self._status["healthy"] and DASH_AVAILABLE,
+            "dash_available": DASH_AVAILABLE,
+            "errors": self._status["errors"],
+            "config": {
+                "location": self.config.location_name,
+                "zone": self.config.zone_name,
+                "icons_enabled": True
+            }
+        }
+    
+    def create_navbar_layout(self):
+        """Create responsive navbar layout with grid system"""
+        if not DASH_AVAILABLE:
+            return html.Div("Navbar unavailable - Dash components missing", 
+                          className="navbar__fallback")
+        
+        try:
+            return dbc.Navbar(
+                [
+                    dbc.Container(
+                        [
+                            dcc.Location(id="url-i18n"),
+                            # Main grid container
+                            html.Div(
+                                [
+                                    # Left Column: Logo Area
+                                    html.Div(
+                                        [
+                                            html.A(
+                                                html.Img(
+                                                    src=self.config.logo_path,
+                                                    height=self.config.logo_height,
+                                                    className="navbar__logo",
                                                 ),
-                                                html.Small(
-                                                    _l(
-                                                        "Logged in as: HQ Tower - East Wing"
+                                                href="/",
+                                                className="navbar__logo-link",
+                                                style={"text-decoration": "none"}
+                                            )
+                                        ],
+                                        className="navbar__left-column",
+                                    ),
+                                    
+                                    # Center Column: Main Panel Label & Context
+                                    html.Div(
+                                        [
+                                            html.Div(
+                                                f"Main Panel: {self.config.location_name} – {self.config.zone_name}",
+                                                className="navbar__main-label",
+                                            ),
+                                            html.Div(
+                                                [
+                                                    html.Span(
+                                                        f"Logged in as: {self.config.user_info}",
+                                                        className="navbar__user-info"
                                                     ),
-                                                    className="navbar__subtitle text-secondary",
-                                                ),
-                                                html.Small(
-                                                    id="live-time",
-                                                    className="navbar__subtitle text-tertiary",
-                                                ),
-                                            ],
-                                            className="text-center",
-                                        )
-                                    ]
-                                )
-                            ],
-                            align="center",
-                            className="flex-grow-1",
-                        ),
-                        # Navigation links
-                        dbc.Row(
-                            [
-                                dbc.Col(
-                                    [
-                                        dbc.Nav(
-                                            [
-                                                dbc.NavItem(
-                                                    dbc.NavLink(
-                                                        _l("Dashboard"),
-                                                        href="/",
-                                                        className="nav-link",
-                                                        active="exact",
-                                                    )
-                                                ),
-                                                dbc.NavItem(
-                                                    dbc.NavLink(
-                                                        _l("File Upload"),
-                                                        href="/file-upload",
-                                                        className="nav-link",
-                                                        active="exact",
-                                                    )
-                                                ),
-                                                dbc.NavItem(
-                                                    dbc.NavLink(
-                                                        _l("Deep Analytics"),
-                                                        href="/analytics",
-                                                        className="nav-link",
-                                                        active="exact",
-                                                    )
-                                                ),
-                                                dbc.NavItem(
-                                                    dbc.NavLink(
-                                                        _l("Export Log"),
-                                                        href="#",
-                                                        className="nav-link",
-                                                    )
-                                                ),
-                                                dbc.NavItem(
-                                                    dbc.NavLink(
-                                                        _l("Settings"),
-                                                        href="#",
-                                                        className="nav-link",
-                                                    )
-                                                ),
-                                            ],
-                                            navbar=True,
-                                            className="navbar__nav",
-                                        )
-                                    ]
-                                )
-                            ],
-                            align="center",
-                        ),
-                        dbc.DropdownMenu(
-                            children=[
-                                dbc.DropdownMenuItem(_l("English"), id="set-en"),
-                                dbc.DropdownMenuItem(_l("Japanese"), id="set-ja"),
-                            ],
-                            nav=True,
-                            in_navbar=True,
-                            label=_l("Language"),
-                            className="ms-2",
-                        ),
-                    ],
-                    fluid=True,
-                    className="navbar__container",
-                )
+                                                    html.Span(
+                                                        [
+                                                            html.Span("🟢", className="status-indicator"),
+                                                            html.Span(
+                                                                id="live-time",
+                                                                children="Live: 2025-06-20 09:55:54",
+                                                                className="navbar__live-time"
+                                                            )
+                                                        ],
+                                                        className="ml-2"
+                                                    ) if self.config.enable_live_time else None
+                                                ],
+                                                className="navbar__status-bar",
+                                            )
+                                        ],
+                                        className="navbar__center-column",
+                                    ),
+                                    
+                                    # Right Column: Navigation Icons + Language Toggle
+                                    html.Div(
+                                        [
+                                            # Navigation Icons
+                                            self._create_navigation_icons(),
+                                            
+                                            # Language Toggle
+                                            self._create_language_toggle() if self.config.enable_language_toggle else None,
+                                        ],
+                                        className="navbar__right-column",
+                                    ),
+                                ],
+                                className="navbar__grid-container",
+                            ),
+                        ],
+                        fluid=True,
+                        className="navbar__container"
+                    )
+                ],
+                color="dark",
+                dark=True,
+                sticky="top",
+                className="navbar__main"
+            )
+            
+        except Exception as e:
+            logger.error(f"Error creating navbar layout: {e}")
+            self._status["errors"].append(str(e))
+            return html.Div("Navbar error", className="navbar__fallback")
+    
+    def _create_navigation_icons(self):
+        """Create navigation icons with hover effects"""
+        nav_items = [
+            {"icon": "dashboard.png", "href": "/", "title": "Dashboard", "alt": "Dashboard"},
+            {"icon": "analytics.png", "href": "/analytics", "title": "Analytics", "alt": "Analytics"},
+            {"icon": "upload.png", "href": "/file-upload", "title": "File Upload", "alt": "Upload"},
+            {"icon": "print.png", "href": "/export", "title": "Export", "alt": "Export"},
+            {"icon": "setting.png", "href": "/settings", "title": "Settings", "alt": "Settings"},
+            {"icon": "logout.png", "href": "/logout", "title": "Logout", "alt": "Logout"},
+        ]
+        
+        return html.Div(
+            [
+                html.A(
+                    html.Img(
+                        src=f"{self.config.icons_base_path}/{item['icon']}",
+                        className="navbar__icon",
+                        alt=item["alt"]
+                    ),
+                    href=item["href"],
+                    className="navbar__nav-link",
+                    title=item["title"]
+                ) for item in nav_items
             ],
-            color="dark",
-            dark=True,
-            className="navbar",
+            className="navbar__icons-container",
         )
-    except Exception as e:
-        print(f"Error creating navbar: {e}")
-        return html.Div("Navigation not available")
+    
+    def _create_language_toggle(self):
+        """Create language toggle component"""
+        return html.Div(
+            [
+                html.Span("EN", className="navbar__lang-option navbar__lang-active"),
+                html.Span(" | ", className="navbar__lang-separator"),
+                html.Span("JP", className="navbar__lang-option"),
+            ],
+            className="navbar__language-toggle ml-4",
+            id="language-toggle"
+        )
+    
+    def register_callbacks(self, app: Any, container: Any) -> bool:
+        """Register navbar callbacks"""
+        if not DASH_AVAILABLE:
+            return False
+            
+        try:
+            self._app = app
+            
+            # Live time update callback
+            if self.config.enable_live_time:
+                @app.callback(
+                    Output("live-time", "children"),
+                    Input("url-i18n", "pathname"),
+                )
+                @safe_callback
+                def update_live_time(pathname):
+                    """Update live time display"""
+                    current_time = datetime.datetime.now().strftime("%Y-%m-%d %H:%M:%S")
+                    return f"Live: {current_time}"
+            
+            # Language toggle callback (if enabled)
+            if self.config.enable_language_toggle:
+                @app.callback(
+                    Output("language-toggle", "children"),
+                    Input("language-toggle", "n_clicks"),
+                    prevent_initial_call=True
+                )
+                @safe_callback
+                def toggle_language(n_clicks):
+                    """Toggle between EN and JP languages"""
+                    if n_clicks and n_clicks % 2 == 1:
+                        return [
+                            html.Span("EN", className="navbar__lang-option"),
+                            html.Span(" | ", className="navbar__lang-separator"),
+                            html.Span("JP", className="navbar__lang-option navbar__lang-active"),
+                        ]
+                    else:
+                        return [
+                            html.Span("EN", className="navbar__lang-option navbar__lang-active"),
+                            html.Span(" | ", className="navbar__lang-separator"),
+                            html.Span("JP", className="navbar__lang-option"),
+                        ]
+            
+            logger.info("Navbar callbacks registered successfully")
+            return True
+            
+        except Exception as e:
+            logger.error(f"Failed to register navbar callbacks: {e}")
+            self._status["errors"].append(str(e))
+            return False
 
 
-# Create the layout
-layout = create_navbar_layout()
+# Plugin factory function
+def create_plugin() -> NavbarPlugin:
+    """Factory function to create navbar plugin instance"""
+    return NavbarPlugin()
 
 
-# Safe callback registration
+# Backward compatibility functions
+def create_navbar_layout():
+    """Backward compatibility function"""
+    plugin = create_plugin()
+    return plugin.create_navbar_layout()
+
+
 def register_navbar_callbacks(app):
-    """Register navbar callbacks safely"""
-    if not DASH_AVAILABLE:
-        return
+    """Backward compatibility function"""
+    plugin = create_plugin()
+    return plugin.register_callbacks(app, None)
 
-    try:
 
-        @app.callback(
-            Output("live-time", "children"),
-            Input("live-time", "id"),
-            prevent_initial_call=False,
-        )
-        @safe_callback
-        def update_time(_):
-            try:
-                return f"Live Time: {datetime.datetime.now().strftime('%Y-%m-%d %H:%M:%S')}"
-            except Exception:
-                return "Time unavailable"
-
-    except Exception as e:
-        print(f"Error registering navbar callbacks: {e}")
+# Export the plugin and compatibility functions
+layout = create_navbar_layout
+__all__ = ["NavbarPlugin", "create_plugin", "create_navbar_layout", "register_navbar_callbacks", "layout"]


### PR DESCRIPTION
## Summary
- implement Navbar plugin with grid layout and callbacks
- add corresponding CSS styles for plugin
- integrate navbar plugin wrapper
- enable navbar plugin in config

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'dash')*

------
https://chatgpt.com/codex/tasks/task_e_6854c1c88e048320919da663cc804ff1