### PR TITLE
Add settings modal popup

### DIFF
--- a/app.py
+++ b/app.py
@@ -84,6 +84,10 @@ def create_full_dashboard() -> Optional[Any]:
         from core.layout_manager import LayoutManager
         from core.callback_manager import CallbackManager
         from core.container import Container
+        from components.settings_modal import (
+            create_settings_modal,
+            register_settings_modal_callbacks,
+        )
 
         # Create container for dependency injection
         container = Container()
@@ -94,10 +98,17 @@ def create_full_dashboard() -> Optional[Any]:
         callback_manager = CallbackManager(app, component_registry, layout_manager, container)
 
         # Step 4: Create main layout using your layout manager
-        app.layout = layout_manager.create_main_layout()
+        main_layout = layout_manager.create_main_layout()
+
+        if hasattr(main_layout, "children") and isinstance(main_layout.children, list):
+            # Insert settings modal after navbar
+            main_layout.children.insert(2, create_settings_modal())
+
+        app.layout = main_layout
 
         # Step 5: Register all callbacks using your callback manager
         callback_manager.register_all_callbacks()
+        register_settings_modal_callbacks(app)
 
         # Store references in app
         app._yosai_json_plugin = json_plugin

--- a/assets/dashboard.css
+++ b/assets/dashboard.css
@@ -350,3 +350,126 @@ html, body, #root, .dash-app {
     object-fit: contain;
   }
 }
+
+/* Settings Modal - Uses existing color variables */
+.settings-modal-overlay {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background-color: rgba(0, 0, 0, 0.5);
+  z-index: 1050;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.settings-modal-overlay.hidden {
+  display: none;
+}
+
+.settings-modal-content {
+  background-color: var(--color-surface);
+  color: var(--color-text-primary);
+  width: 400px;
+  max-width: 90vw;
+  border-radius: 12px;
+  box-shadow: 0 10px 25px rgba(0, 0, 0, 0.3);
+  position: relative;
+  animation: modalSlideIn 0.3s ease-out;
+}
+
+@keyframes modalSlideIn {
+  from {
+    transform: translateY(-20px);
+    opacity: 0;
+  }
+  to {
+    transform: translateY(0);
+    opacity: 1;
+  }
+}
+
+.settings-modal-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 1.5rem;
+  border-bottom: 1px solid var(--color-border);
+}
+
+.settings-modal-title {
+  font-size: 1.125rem;
+  font-weight: bold;
+  color: var(--color-text-primary);
+  margin: 0;
+}
+
+.settings-modal-close {
+  background: none;
+  border: none;
+  color: var(--color-text-tertiary);
+  font-size: 1.5rem;
+  cursor: pointer;
+  padding: 0.25rem;
+  line-height: 1;
+  transition: color 0.3s ease;
+}
+
+.settings-modal-close:hover {
+  color: var(--color-text-primary);
+}
+
+.settings-modal-body {
+  padding: 1.5rem;
+}
+
+.settings-item-list {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+}
+
+.settings-item {
+  display: flex;
+  align-items: center;
+  padding: 0.75rem;
+  border-radius: 6px;
+  cursor: pointer;
+  transition: background-color 0.3s ease;
+  margin-bottom: 0.5rem;
+}
+
+.settings-item:hover {
+  background-color: var(--color-primary);
+}
+
+.settings-item:last-child {
+  margin-bottom: 0;
+}
+
+.settings-item-icon {
+  width: 20px;
+  height: 20px;
+  margin-right: 0.75rem;
+  filter: brightness(0.9);
+  transition: filter 0.3s ease;
+}
+
+.settings-item:hover .settings-item-icon {
+  filter: brightness(1.1);
+}
+
+.settings-item-text {
+  color: var(--color-text-primary);
+  font-size: 0.875rem;
+  font-weight: 500;
+}
+
+@media (max-width: 768px) {
+  .settings-modal-content {
+    width: 350px;
+    margin: 1rem;
+  }
+}

--- a/components/__init__.py
+++ b/components/__init__.py
@@ -21,10 +21,19 @@ except ImportError as e:
     logger.warning(f"Analytics components not available: {e}")
     ANALYTICS_AVAILABLE = False
 
-__all__ = ['NAVBAR_AVAILABLE', 'ANALYTICS_AVAILABLE']
+try:
+    from .settings_modal import create_settings_modal, register_settings_modal_callbacks
+    SETTINGS_MODAL_AVAILABLE = True
+except ImportError as e:
+    logger.warning(f"Settings modal component not available: {e}")
+    SETTINGS_MODAL_AVAILABLE = False
+
+__all__ = ['NAVBAR_AVAILABLE', 'ANALYTICS_AVAILABLE', 'SETTINGS_MODAL_AVAILABLE']
 
 if NAVBAR_AVAILABLE:
     __all__.append('create_navbar')
 if ANALYTICS_AVAILABLE:
     __all__.append('analytics')
+if SETTINGS_MODAL_AVAILABLE:
+    __all__.extend(['create_settings_modal', 'register_settings_modal_callbacks'])
 

--- a/components/settings_modal.py
+++ b/components/settings_modal.py
@@ -1,0 +1,175 @@
+"""Settings Modal Component"""
+from dash import html, clientside_callback, Input, Output
+from typing import Any
+import logging
+
+logger = logging.getLogger(__name__)
+
+# Safe import handling
+try:
+    from dash import dcc
+    DASH_AVAILABLE = True
+except ImportError:
+    logger.warning("Dash not available for settings modal")
+    DASH_AVAILABLE = False
+
+
+def create_settings_modal() -> html.Div:
+    """Create the settings modal component"""
+
+    if not DASH_AVAILABLE:
+        return html.Div("Settings modal not available")
+
+    settings_items = [
+        {"icon": "/assets/navbar_icons/folder.png", "text": "Critical Doors", "id": "critical-doors"},
+        {"icon": "/assets/navbar_icons/folder.png", "text": "Event Reason Aliases", "id": "event-aliases"},
+        {"icon": "/assets/navbar_icons/folder.png", "text": "Insights Settings", "id": "insights-settings"},
+        {"icon": "/assets/navbar_icons/folder.png", "text": "Learning Rate", "id": "learning-rate"},
+        {"icon": "/assets/navbar_icons/settings.png", "text": "Manage Auth", "id": "manage-auth"},
+        {"icon": "/assets/navbar_icons/folder.png", "text": "Resolution Tags", "id": "resolution-tags"},
+        {"icon": "/assets/navbar_icons/folder.png", "text": "System Admin Tools", "id": "system-admin"},
+        {"icon": "/assets/navbar_icons/folder.png", "text": "Ticket Criticality", "id": "ticket-criticality"},
+        {"icon": "/assets/navbar_icons/folder.png", "text": "Ticket Generation", "id": "ticket-generation"},
+        {"icon": "/assets/navbar_icons/settings.png", "text": "User Management", "id": "user-management"},
+    ]
+
+    try:
+        modal_content = html.Div(
+            [
+                html.Div(
+                    html.Div(
+                        [
+                            html.Div(
+                                [
+                                    html.H2("Settings", className="settings-modal-title"),
+                                    html.Button(
+                                        "×",
+                                        id="settings-modal-close-btn",
+                                        className="settings-modal-close",
+                                    ),
+                                ],
+                                className="settings-modal-header",
+                            ),
+                            html.Div(
+                                html.Ul(
+                                    [
+                                        html.Li(
+                                            [
+                                                html.Img(
+                                                    src=item["icon"],
+                                                    className="settings-item-icon",
+                                                    alt="",
+                                                ),
+                                                html.Span(
+                                                    item["text"],
+                                                    className="settings-item-text",
+                                                ),
+                                            ],
+                                            className="settings-item",
+                                            id=f"settings-{item['id']}",
+                                        )
+                                        for item in settings_items
+                                    ],
+                                    className="settings-item-list",
+                                ),
+                                className="settings-modal-body",
+                            ),
+                        ],
+                        className="settings-modal-content",
+                    ),
+                    className="settings-modal-overlay hidden",
+                    id="settings-modal-overlay",
+                )
+            ],
+            id="settings-modal-container",
+        )
+
+        return modal_content
+
+    except Exception as e:
+        logger.error(f"Error creating settings modal: {e}")
+        return html.Div(f"Settings modal error: {e}", className="text-danger")
+
+
+def register_settings_modal_callbacks(app):
+    """Register callbacks for settings modal functionality"""
+
+    if not DASH_AVAILABLE:
+        return
+
+    try:
+        app.clientside_callback(
+            """
+            function(n_clicks_open, n_clicks_close, n_clicks_overlay) {
+                const ctx = dash_clientside.callback_context;
+                if (!ctx.triggered.length) {
+                    return dash_clientside.no_update;
+                }
+
+                const triggered_id = ctx.triggered[0].prop_id.split('.')[0];
+                const modal = document.getElementById('settings-modal-overlay');
+
+                if (!modal) return dash_clientside.no_update;
+
+                if (triggered_id === 'navbar-settings-btn') {
+                    modal.classList.remove('hidden');
+                } else if (triggered_id === 'settings-modal-close-btn') {
+                    modal.classList.add('hidden');
+                } else if (triggered_id === 'settings-modal-overlay' && n_clicks_overlay) {
+                    modal.classList.add('hidden');
+                }
+
+                return dash_clientside.no_update;
+            }
+            """,
+            Output("settings-modal-container", "style"),
+            [
+                Input("navbar-settings-btn", "n_clicks"),
+                Input("settings-modal-close-btn", "n_clicks"),
+                Input("settings-modal-overlay", "n_clicks"),
+            ],
+        )
+
+        @app.callback(
+            Output("url", "pathname"),
+            [
+                Input("settings-critical-doors", "n_clicks"),
+                Input("settings-event-aliases", "n_clicks"),
+                Input("settings-insights-settings", "n_clicks"),
+                Input("settings-learning-rate", "n_clicks"),
+                Input("settings-manage-auth", "n_clicks"),
+                Input("settings-resolution-tags", "n_clicks"),
+                Input("settings-system-admin", "n_clicks"),
+                Input("settings-ticket-criticality", "n_clicks"),
+                Input("settings-ticket-generation", "n_clicks"),
+                Input("settings-user-management", "n_clicks"),
+            ],
+            prevent_initial_call=True,
+        )
+        def handle_settings_navigation(*args):
+            ctx = dash.callback_context
+            if not ctx.triggered:
+                return dash.no_update
+
+            settings_routes = {
+                "settings-critical-doors": "/settings/critical-doors",
+                "settings-event-aliases": "/settings/event-aliases",
+                "settings-insights-settings": "/settings/insights",
+                "settings-learning-rate": "/settings/learning-rate",
+                "settings-manage-auth": "/settings/auth",
+                "settings-resolution-tags": "/settings/resolution-tags",
+                "settings-system-admin": "/settings/admin",
+                "settings-ticket-criticality": "/settings/ticket-criticality",
+                "settings-ticket-generation": "/settings/ticket-generation",
+                "settings-user-management": "/settings/users",
+            }
+
+            triggered_id = ctx.triggered[0]["prop_id"].split(".")[0]
+            return settings_routes.get(triggered_id, dash.no_update)
+
+    except Exception as e:
+        logger.error(f"Error registering settings modal callbacks: {e}")
+
+
+layout = create_settings_modal
+__all__ = ["create_settings_modal", "register_settings_modal_callbacks", "layout"]

--- a/dashboard/layout/navbar.py
+++ b/dashboard/layout/navbar.py
@@ -149,15 +149,21 @@ def create_navbar_layout():
                                                             className="navbar-nav-link",
                                                             title="Export"
                                                         ),
-                                                        html.A(
+                                                        html.Button(
                                                             html.Img(
-                                                                src="/assets/navbar_icons/settings.png",  # Changed from setting.png to settings.png
+                                                                src="/assets/navbar_icons/settings.png",
                                                                 className="navbar-icon",
                                                                 alt="Settings"
                                                             ),
-                                                            href="/settings",
+                                                            id="navbar-settings-btn",
                                                             className="navbar-nav-link",
-                                                            title="Settings"
+                                                            title="Settings",
+                                                            style={
+                                                                "background": "none",
+                                                                "border": "none",
+                                                                "padding": "0",
+                                                                "cursor": "pointer",
+                                                            },
                                                         ),
                                                         html.A(
                                                             html.Img(


### PR DESCRIPTION
## Summary
- style settings modal in dashboard CSS
- add modular `settings_modal` component
- export settings modal in component registry
- hook modal into navbar and main layout

## Testing
- `python tests/test_dashboard.py` *(fails: ModuleNotFoundError: No module named 'pandas')*
- `pytest` *(fails: ModuleNotFoundError: No module named 'dash')*
- `mypy .` *(fails: duplicate module error)*
- `black . --check` *(fails: would reformat many files)*
- `flake8 .` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6854d6e683f48320a1c86a519e1c2ff7