### PR TITLE
Restore original dashboard layout

### DIFF
--- a/assets/dashboard.css
+++ b/assets/dashboard.css
@@ -31,10 +31,17 @@ html, body, #root, .dash-app {
   z-index: 100;
 }
 
+.dashboard-layout {
+  display: flex;
+  flex-direction: column;
+  height: calc(100vh - 60px); /* Account for navbar */
+}
+
+/* Main 3-Column Content Area */
 .main-content {
   display: flex;
   flex-direction: row;
-  height: calc(100vh - 15vh - 60px); /* full height minus bottom + navbar */
+  flex: 1;
   overflow: hidden;
 }
 
@@ -61,6 +68,11 @@ html, body, #root, .dash-app {
 }
 
 /* Bottom Panel Layout */
+.bottom-panel-container {
+  border-top: 1px solid var(--color-border);
+}
+
+/* Bottom Panel Layout - Two Columns */
 .bottom-panel {
   display: flex;
   justify-content: space-between;
@@ -69,6 +81,7 @@ html, body, #root, .dash-app {
   color: white;
   font-family: 'Helvetica Neue', sans-serif;
   border-top: 1px solid #2d3748;
+  min-height: 200px;
 }
 
 .bottom-column {
@@ -80,7 +93,8 @@ html, body, #root, .dash-app {
 }
 
 .bottom-column.respond {
-  align-items: center;
+  align-items: flex-start;
+  max-width: 300px;
 }
 
 .bottom-column h4 {
@@ -153,6 +167,7 @@ html, body, #root, .dash-app {
   cursor: pointer;
   font-weight: 600;
   transition: background-color 0.2s ease-in-out;
+  width: 100%;
 }
 
 .complete-button:hover {
@@ -160,15 +175,21 @@ html, body, #root, .dash-app {
 }
 
 /* Resolve Buttons */
+.resolve-buttons {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+}
+
 .resolve-button {
   background-color: #2d3748;
   color: white;
   border: none;
   padding: 0.5rem;
-  margin-top: 0.25rem;
   border-radius: 4px;
   cursor: pointer;
   transition: background-color 0.2s ease-in-out;
+  text-align: left;
 }
 
 .resolve-button:hover {

--- a/components/bottom_panel.py
+++ b/components/bottom_panel.py
@@ -1,71 +1,111 @@
 # yosai_intel_dashboard/components/bottom_panel.py
 
-from dash import html, dcc
+from dash import html
+from flask_babel import lazy_gettext as _l
 
-# Safe text function that works with or without babel
+
 def safe_text(text):
     """Return text safely, handling any babel objects"""
-    return str(text)
+    try:
+        return str(text)
+    except Exception:
+        return text
 
 
 def get_layout():
-    """Return the bottom panel layout without babel dependencies"""
+    """Return the complete bottom panel layout with Incident Detection + Respond sections"""
 
     layout = html.Div(
         [
+            # Left Section: Incident Detection Breakdown
             html.Div(
                 [
-                    html.H4(safe_text("Incident Detection Breakdown")),
+                    html.H4(safe_text(_l("Incident Detection Breakdown"))),
                     html.Div(
                         [
                             html.Div(
                                 [
-                                    html.Div(safe_text(label), className="chip gold")
-                                    for label in [
-                                        "Access Outcome",
-                                        "Unusual Door",
-                                        "Potential Tailgating", 
-                                        "Unusual Group",
-                                    ]
+                                    html.Div(safe_text(_l("Access Outcome")), className="chip gold"),
+                                    html.Div(safe_text(_l("Unusual Door")), className="chip gold"),
+                                    html.Div(safe_text(_l("Potential Tailgating")), className="chip gold"),
+                                    html.Div(safe_text(_l("Unusual Group")), className="chip gold"),
                                 ],
-                                className="chip-row",
+                                className="chip-grid",
                             ),
                             html.Div(
                                 [
-                                    html.Div(safe_text(label), className="chip")
-                                    for label in [
-                                        "Unusual Path",
-                                        "Unusual Time",
-                                        "Multiple Attempts",
-                                        "Location Criticality",
-                                    ]
+                                    html.Div(safe_text(_l("Unusual Path")), className="chip"),
+                                    html.Div(safe_text(_l("Unusual Time")), className="chip"),
+                                    html.Div(safe_text(_l("Multiple Attempts")), className="chip"),
+                                    html.Div(safe_text(_l("Location Criticality")), className="chip"),
                                 ],
-                                className="chip-row",
+                                className="chip-grid",
                             ),
                             html.Div(
                                 [
-                                    html.Div(safe_text(label), className="chip gold")
-                                    for label in [
-                                        "Interaction Effects",
-                                        "Token History",
-                                        "Cross-Location",
-                                        "Cross-Organization",
-                                    ]
+                                    html.Div(safe_text(_l("Interaction Effects")), className="chip gold"),
+                                    html.Div(safe_text(_l("Token History")), className="chip gold"),
+                                    html.Div(safe_text(_l("Cross-Location")), className="chip gold"),
+                                    html.Div(safe_text(_l("Cross-Organization")), className="chip gold"),
                                 ],
-                                className="chip-row",
+                                className="chip-grid",
                             ),
-                            html.Div(safe_text("Technology Core Engine Analysis"), className="tech-note"),
                         ],
                         className="chips-container",
                     ),
                 ],
-                className="incident-breakdown",
+                className="bottom-column",
+            ),
+
+            # Right Section: Respond Panel
+            html.Div(
+                [
+                    html.H4(safe_text(_l("Respond"))),
+
+                    # Active Ticket
+                    html.Div(
+                        [
+                            html.Div(safe_text(_l("Action III")), className="respond-label"),
+                            html.Div(
+                                safe_text(_l("Ticket I Action I")),
+                                className="ticket-box"
+                            ),
+                            html.Button(
+                                safe_text(_l("Mark As Completed")),
+                                className="complete-button"
+                            ),
+                        ]
+                    ),
+
+                    # Action Checklist
+                    html.Div(
+                        [
+                            html.Div(safe_text(_l("Action I")), className="action-checklist"),
+                            html.Div(safe_text(_l("Action II")), className="action-checklist"),
+                            html.Div(safe_text(_l("Action IV")), className="action-checklist"),
+                        ]
+                    ),
+
+                    # Resolve Buttons
+                    html.Div(
+                        [
+                            html.Button(safe_text(_l("Resolve As Harmful")), className="resolve-button"),
+                            html.Button(safe_text(_l("Resolve As Malfunction")), className="resolve-button"),
+                            html.Button(safe_text(_l("Resolve As Normal")), className="resolve-button"),
+                            html.Button(safe_text(_l("Dismiss")), className="resolve-button"),
+                        ],
+                        className="resolve-buttons"
+                    ),
+                ],
+                className="bottom-column respond",
             ),
         ],
         className="bottom-panel",
     )
-    
+
     return layout
+
 
 # For backwards compatibility, expose the layout directly
 layout = get_layout()
+

--- a/core/layout_manager.py
+++ b/core/layout_manager.py
@@ -70,50 +70,53 @@ class LayoutManager:
             return html.Div(f"Layout error: {str(e)}", className="alert alert-danger")
     
     def create_dashboard_content(self) -> Any:
-        """Create dashboard content grid"""
+        """Create dashboard content with original 3-column + bottom layout"""
         if not DASH_AVAILABLE:
             logger.error("Dash components not available for dashboard content")
             return "Dashboard content not available"
-        
+
         try:
-            # Create dashboard grid layout
+            # Create the original 3-column layout
             left_panel = html.Div([
                 self.registry.get_component_or_fallback(
                     'incident_alerts',
                     "Incident Alerts Panel - Component not available"
                 )
-            ], className="dashboard__left-panel")
-            
+            ], className="left-panel")
+
             map_panel = html.Div([
                 self.registry.get_component_or_fallback(
                     'map_panel',
                     "Map Panel - Component not available"
                 )
-            ], className="dashboard__map-panel")
-            
+            ], className="map-panel")
+
             right_panel = html.Div([
                 self.registry.get_component_or_fallback(
                     'weak_signal',
-                    "Weak Signal Feed - Component not available"
+                    "Comprehensive Reports Panel - Component not available"
                 )
-            ], className="dashboard__right-panel")
-            
-            content_grid = html.Div([
+            ], className="right-panel")
+
+            # Create main content area (3-column layout)
+            main_content = html.Div([
                 left_panel,
                 map_panel,
                 right_panel,
-            ], className="dashboard__content")
-            
-            bottom_panel = self.registry.get_component_or_fallback(
-                'bottom_panel',
-                "Bottom Panel - Component not available"
-            )
-            
-            return html.Div([content_grid, bottom_panel])
-            
+            ], className="main-content")
+
+            # Create bottom panel with both sections
+            bottom_panel = html.Div([
+                self.registry.get_component_or_fallback(
+                    'bottom_panel',
+                    "Bottom Panel - Component not available"
+                )
+            ], className="bottom-panel-container")
+
+            return html.Div([main_content, bottom_panel], className="dashboard-layout")
+
         except Exception as e:
             logger.error(f"Error creating dashboard content: {e}")
-            # html is guaranteed to be available here since DASH_AVAILABLE is True
             return html.Div(f"Dashboard content error: {str(e)}", className="alert alert-danger")
     
     def create_safe_fallback_layout(self) -> str:


### PR DESCRIPTION
## Summary
- revert dashboard content creation to 3 column layout with bottom panel
- rebuild bottom panel component with incident detection and respond sections
- update CSS to support restored layout

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'dash')*

------
https://chatgpt.com/codex/tasks/task_e_6854e00baa7883209cb3043805146755