### PR TITLE
Fix duplicate id in upload component

### DIFF
--- a/components/analytics/file_uploader.py
+++ b/components/analytics/file_uploader.py
@@ -43,8 +43,6 @@ def create_dual_file_uploader(upload_id: str = 'analytics-file-upload') -> html.
                                 html.P("✅ Excel files (.xlsx, .xls)")
                             ], className="upload-supported-types")
                         ]),
-                        className="upload-box upload-box-active",
-                        id=f"{upload_id}-box",
                         multiple=True,
                         accept='.csv,.json,.xlsx,.xls,application/json,application/vnd.openxmlformats-officedocument.spreadsheetml.sheet,application/vnd.ms-excel,text/csv'
                     ),
@@ -54,7 +52,10 @@ def create_dual_file_uploader(upload_id: str = 'analytics-file-upload') -> html.
                         html.Div(className="upload-spinner"),
                         html.Div("Processing file...", id=f"{upload_id}-progress-text")
                     ], className="upload-progress-overlay", id=f"{upload_id}-progress")
-                ], style={"position": "relative"}),
+                ],
+                id=f"{upload_id}-box",
+                className="upload-box upload-box-active",
+                style={"position": "relative"}),
 
                 # Right Box - Database Upload Placeholder
                 html.Div([


### PR DESCRIPTION
## Summary
- correct the dual file uploader to use only one id for `dcc.Upload`
- attach styling and identifier to parent div so callbacks continue to work

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'dash')*

------
https://chatgpt.com/codex/tasks/task_e_6854e5850a3c8320aef917e91fefc006