### PR TITLE
Fix repeated keyword in uploader

### DIFF
--- a/components/analytics/file_uploader.py
+++ b/components/analytics/file_uploader.py
@@ -44,7 +44,6 @@ def create_dual_file_uploader(upload_id: str = 'analytics-file-upload') -> html.
                             ], className="upload-supported-types")
                         ]),
                         className="upload-box upload-box-active",
-                        id=f"{upload_id}-box",
                         multiple=True,
                         accept='.csv,.json,.xlsx,.xls,application/json,application/vnd.openxmlformats-officedocument.spreadsheetml.sheet,application/vnd.ms-excel,text/csv'
                     ),
@@ -54,7 +53,7 @@ def create_dual_file_uploader(upload_id: str = 'analytics-file-upload') -> html.
                         html.Div(className="upload-spinner"),
                         html.Div("Processing file...", id=f"{upload_id}-progress-text")
                     ], className="upload-progress-overlay", id=f"{upload_id}-progress")
-                ], style={"position": "relative"}),
+                ], style={"position": "relative"}, id=f"{upload_id}-box"),
 
                 # Right Box - Database Upload Placeholder
                 html.Div([


### PR DESCRIPTION
## Summary
- avoid repeating the `id` keyword in the analytics file uploader

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'dash')*

------
https://chatgpt.com/codex/tasks/task_e_6854ea8212d883209cfe8b15c5065dd8