### PR TITLE
Fix NameError for settings modal callbacks

### DIFF
--- a/components/settings_modal.py
+++ b/components/settings_modal.py
@@ -1,5 +1,6 @@
 """Settings Modal Component"""
 from dash import html, clientside_callback, Input, Output
+import dash
 from typing import Any
 import logging
 


### PR DESCRIPTION
## Summary
- fix NameError by importing `dash` in settings_modal

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'dash')*

------
https://chatgpt.com/codex/tasks/task_e_6854f04664ac832087f19aa843ed492f