### PR TITLE
Fix duplicated file upload callbacks

### DIFF
--- a/app.py
+++ b/app.py
@@ -110,13 +110,6 @@ def create_full_dashboard() -> Optional[Any]:
         callback_manager.register_all_callbacks()
         register_settings_modal_callbacks(app)
 
-        try:
-            from pages import register_page_callbacks
-            register_page_callbacks('file_upload', app, container)
-            print("✅ File upload callbacks registered")
-        except Exception as e:
-            print(f"❌ Failed to register file upload callbacks: {e}")
-
         # Store references in app
         app._yosai_json_plugin = json_plugin
         app._yosai_container = container


### PR DESCRIPTION
## Summary
- avoid registering file upload callbacks twice

## Testing
- `python tests/test_modular_system.py` *(fails: ModuleNotFoundError: No module named 'pandas')*
- `python tests/test_dashboard.py` *(fails: ModuleNotFoundError: No module named 'pandas')*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'dash')*
- `mypy .`
- `black . --check` *(fails: many files would be reformatted)*
- `flake8 .` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6854f456e8a48320b672671e63b4053f