### PR TITLE
Ensure JSON-safe layouts and registry update

### DIFF
--- a/components/map_panel.py
+++ b/components/map_panel.py
@@ -70,10 +70,6 @@ layout = html.Div(
     style={"width": "100%", "height": "100%", "backgroundColor": "#121212"},
 )
 
-# Convert any LazyString objects to regular strings for safe serialization
-layout = sanitize_lazystring_recursive(layout)
-
-
 # Register callbacks
 
 
@@ -97,4 +93,7 @@ def register_callbacks(app):
             if not ctx.triggered:
                 return no_update
             button_id = ctx.triggered[0]["prop_id"].split(".")[0]
-            return view_centers.get(button_id.split("-")[-1], view_centers["site"])
+            return view_centers.get(button_id.split("-")[-1], view_centers["site"]) 
+
+# Convert any LazyString objects to regular strings for safe serialization
+layout = sanitize_lazystring_recursive(layout)

--- a/core/component_registry.py
+++ b/core/component_registry.py
@@ -15,7 +15,7 @@ class ComponentRegistry:
 
     def _load_all_components(self) -> None:
         """Load all components with error handling"""
-        # Load your actual components with fallbacks
+        # Load components from specific files
         self._components["navbar"] = self._safe_import_component(
             "dashboard.layout.navbar", "create_navbar_layout"
         )


### PR DESCRIPTION
## Summary
- load components from specific files in registry
- sanitize map panel layout at end of file

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'dash')*

------
https://chatgpt.com/codex/tasks/task_e_6854f6dd23fc83208933f5322a4f07fc