### PR TITLE
Add sanitized dashboard panels

### DIFF
--- a/components/bottom_panel.py
+++ b/components/bottom_panel.py
@@ -1,9 +1,6 @@
-# yosai_intel_dashboard/components/bottom_panel.py
-
 from dash import html
 from flask_babel import lazy_gettext as _l
 from utils.lazystring_handler import sanitize_lazystring_recursive
-
 
 def get_layout():
     """Return the complete bottom panel layout with both sections"""

--- a/components/incident_alerts_panel.py
+++ b/components/incident_alerts_panel.py
@@ -1,5 +1,3 @@
-# yosai_intel_dashboard/components/incident_alerts_panel.py
-
 from dash import html, dcc, callback, Output, Input, State
 import dash_bootstrap_components as dbc
 from flask_babel import lazy_gettext as _l
@@ -27,11 +25,8 @@ TICKET_CATEGORIES = [
     {"label": _l("Dismissed Tickets"), "color": "light", "id": "ticket-dismissed"},
 ]
 
-
 # Sample ticket card layout
-def ticket_card(
-    ticket_id, threat_score, location, timestamp, area, device, group, result
-):
+def ticket_card(ticket_id, threat_score, location, timestamp, area, device, group, result):
     return dbc.Card(
         [
             dbc.CardHeader(f"Event ID: {ticket_id}", className="ticket-id"),
@@ -39,15 +34,12 @@ def ticket_card(
                 [
                     html.Div(
                         [
-                            html.Div(
-                                _l("Threat Level:"), className="ticket-threat-label"
-                            ),
+                            html.Div(_l("Threat Level:"), className="ticket-threat-label"),
                             dbc.Progress(
                                 value=threat_score,
                                 max=100,
                                 color=(
-                                    "success"
-                                    if threat_score <= 40
+                                    "success" if threat_score <= 40
                                     else "warning" if threat_score <= 70 else "danger"
                                 ),
                                 striped=True,
@@ -59,12 +51,8 @@ def ticket_card(
                     html.Hr(),
                     html.Div(
                         [
-                            html.P(
-                                _l("Location: {location}").format(location=location)
-                            ),
-                            html.P(
-                                _l("Timestamp: {timestamp}").format(timestamp=timestamp)
-                            ),
+                            html.P(_l("Location: {location}").format(location=location)),
+                            html.P(_l("Timestamp: {timestamp}").format(timestamp=timestamp)),
                             html.P(_l("Area: {area}").format(area=area)),
                             html.P(_l("Device: {device}").format(device=device)),
                             html.P(_l("Access Group: {group}").format(group=group)),
@@ -76,7 +64,6 @@ def ticket_card(
         ],
         className="ticket-card",
     )
-
 
 # Category section with sample tickets
 def ticket_category_block(cat):
@@ -112,7 +99,7 @@ def ticket_category_block(cat):
         item_id=cat["id"],
     )
 
-
+# Create the main layout
 layout = html.Div(
     [
         html.H4(_l("Incident Alerts"), className="incident-panel-header"),
@@ -126,5 +113,5 @@ layout = html.Div(
     className="incident-alert-panel",
 )
 
-# Sanitize layout to ensure LazyString objects are converted to plain strings
+# JSON SANITIZATION - Convert LazyString objects to regular strings
 layout = sanitize_lazystring_recursive(layout)

--- a/components/map_panel.py
+++ b/components/map_panel.py
@@ -1,7 +1,3 @@
-# pyright: reportArgumentType=false
-
-# yosai_intel_dashboard/components/map_panel.py
-
 import dash_leaflet as dl
 from dash_leaflet import Marker, TileLayer, Tooltip, Popup, ScaleControl, ZoomControl
 from dash import html, dcc, Output, Input, callback_context, no_update
@@ -70,9 +66,10 @@ layout = html.Div(
     style={"width": "100%", "height": "100%", "backgroundColor": "#121212"},
 )
 
+# JSON SANITIZATION - Convert LazyString objects to regular strings
+layout = sanitize_lazystring_recursive(layout)
+
 # Register callbacks
-
-
 def register_callbacks(app):
     if not hasattr(app, "_callback_registered_map_center"):
         app._callback_registered_map_center = True
@@ -93,7 +90,4 @@ def register_callbacks(app):
             if not ctx.triggered:
                 return no_update
             button_id = ctx.triggered[0]["prop_id"].split(".")[0]
-            return view_centers.get(button_id.split("-")[-1], view_centers["site"]) 
-
-# Convert any LazyString objects to regular strings for safe serialization
-layout = sanitize_lazystring_recursive(layout)
+            return view_centers.get(button_id.split("-")[-1], view_centers["site"])

--- a/components/weak_signal_panel.py
+++ b/components/weak_signal_panel.py
@@ -1,13 +1,7 @@
-# yosai_intel_dashboard/components/weak_signal_panel.py
-
 from dash import html
 import dash_bootstrap_components as dbc
+from flask_babel import lazy_gettext as _l
 from utils.lazystring_handler import sanitize_lazystring_recursive
-
-# Safe text function that works with or without babel
-def safe_text(text):
-    """Return text safely, handling any babel objects"""
-    return str(text)
 
 # Example signal card
 def signal_card(prefix, code, severity, location, description, timestamp):
@@ -15,14 +9,14 @@ def signal_card(prefix, code, severity, location, description, timestamp):
     return dbc.Card(
         [
             dbc.CardHeader(
-                safe_text(f"[{prefix}-{code}] - {severity}"),
+                f"[{prefix}-{code}] - {severity}",
                 className=f"signal-card-header {severity_class}",
             ),
             dbc.CardBody(
                 [
-                    html.P(safe_text(f"Location: {location}")),
-                    html.P(safe_text(f"Description: {description}")),
-                    html.P(safe_text(f"Timestamp: {timestamp}")),
+                    html.P(f"Location: {location}"),
+                    html.P(f"Description: {description}"),
+                    html.P(f"Timestamp: {timestamp}"),
                 ]
             ),
         ],
@@ -34,7 +28,7 @@ def category_block(title, signals, category_id):
     return html.Details(
         [
             html.Summary(
-                safe_text(f"{title} ({len(signals)})"),
+                f"{title} ({len(signals)})",
                 className="signal-summary",
             ),
             html.Div(signals, className="signal-category-content"),
@@ -45,9 +39,9 @@ def category_block(title, signals, category_id):
 
 layout = html.Div(
     [
-        html.H4(safe_text("Weak-Signal Live Feed"), className="panel-header"),
+        html.H4(_l("Weak-Signal Live Feed"), className="panel-header"),
         category_block(
-            safe_text("News Scraping"),
+            _l("News Scraping"),
             [
                 signal_card(
                     "N",
@@ -61,7 +55,7 @@ layout = html.Div(
             "weak-signal-news",
         ),
         category_block(
-            safe_text("Cross-Location"),
+            _l("Cross-Location"),
             [
                 signal_card(
                     "CO",
@@ -78,5 +72,5 @@ layout = html.Div(
     className="weak-signal-panel",
 )
 
-# Convert any LazyString objects to regular strings for safe serialization  
+# JSON SANITIZATION - Convert LazyString objects to regular strings  
 layout = sanitize_lazystring_recursive(layout)

--- a/utils/lazystring_handler.py
+++ b/utils/lazystring_handler.py
@@ -1,9 +1,35 @@
+"""Handle LazyString objects for JSON serialization"""
+import logging
 from typing import Any
-from .lazystring_utils import sanitize_json_data
 
+logger = logging.getLogger(__name__)
 
-def sanitize_lazystring_recursive(data: Any) -> Any:
-    """Recursively convert LazyString objects to plain strings."""
-    return sanitize_json_data(data)
-
-__all__ = ["sanitize_lazystring_recursive"]
+def sanitize_lazystring_recursive(obj: Any) -> Any:
+    """Recursively convert LazyString objects to regular strings for JSON serialization"""
+    try:
+        if hasattr(obj, '__iter__') and not isinstance(obj, (str, bytes)):
+            if isinstance(obj, dict):
+                return {k: sanitize_lazystring_recursive(v) for k, v in obj.items()}
+            elif isinstance(obj, list):
+                return [sanitize_lazystring_recursive(item) for item in obj]
+            elif isinstance(obj, tuple):
+                return tuple(sanitize_lazystring_recursive(item) for item in obj)
+        
+        # Handle LazyString objects (from Flask-Babel)
+        if hasattr(obj, '__html__') or str(type(obj)).find('LazyString') != -1:
+            return str(obj)
+        
+        # Handle Dash components
+        if hasattr(obj, 'to_plotly_json'):
+            json_obj = obj.to_plotly_json()
+            return sanitize_lazystring_recursive(json_obj)
+        
+        # Handle objects with children attribute
+        if hasattr(obj, 'children'):
+            obj.children = sanitize_lazystring_recursive(obj.children)
+        
+        return obj
+        
+    except Exception as e:
+        logger.warning(f"Error sanitizing object {type(obj)}: {e}")
+        return str(obj) if obj is not None else None


### PR DESCRIPTION
## Summary
- update incident alerts panel layout and sanitize output
- update map panel layout and sanitize output
- update bottom panel content and sanitize output
- update weak-signal panel content and sanitize output
- provide recursive LazyString sanitization helper

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'dash')*

------
https://chatgpt.com/codex/tasks/task_e_6855146a905c83209457ec0cc0a0248d