### PR TITLE
Refactor file uploader into plugin

### DIFF
--- a/components/__init__.py
+++ b/components/__init__.py
@@ -37,9 +37,12 @@ if ANALYTICS_AVAILABLE:
 if SETTINGS_MODAL_AVAILABLE:
     __all__.extend(['create_settings_modal', 'register_settings_modal_callbacks'])
 
-# Dual upload component
+# Dual upload component is now provided via plugin
 try:
-    from .analytics.file_uploader import create_dual_file_uploader, register_dual_upload_callbacks
+    from plugins.file_upload_plugin import (
+        create_dual_file_uploader,
+        register_dual_upload_callbacks,
+    )
     DUAL_UPLOAD_AVAILABLE = True
 except Exception as e:
     logger.warning(f"Dual upload component not available: {e}")

--- a/components/analytics/__init__.py
+++ b/components/analytics/__init__.py
@@ -5,12 +5,13 @@ Analytics components module - Type-safe imports
 
 # Import main component functions with error handling
 try:
-    from .file_uploader import create_file_uploader
+    from plugins.file_upload_plugin import create_file_uploader, FileProcessor
 except ImportError as e:
-    print(f"Warning: Could not import file_uploader: {e}")
+    print(f"Warning: Could not import file_upload_plugin: {e}")
     def create_file_uploader(*args, **kwargs):
         from dash import html
         return html.Div("File uploader component not available")
+    FileProcessor = None
 
 try:
     from .data_preview import create_data_preview
@@ -32,13 +33,13 @@ except ImportError as e:
         from dash import html
         return html.Div("Summary cards component not available")
 
-# Handle file processing imports
-FileProcessor = None
+# Handle file processing imports if not provided by the plugin
 AnalyticsGenerator = None
 
 try:
-    from .file_processing import FileProcessor as _FileProcessor, AnalyticsGenerator as _AnalyticsGenerator
-    FileProcessor = _FileProcessor
+    from .file_processing import FileProcessor as _FP, AnalyticsGenerator as _AnalyticsGenerator
+    if 'FileProcessor' not in globals() or FileProcessor is None:
+        FileProcessor = _FP
     AnalyticsGenerator = _AnalyticsGenerator
 except ImportError as e:
     print(f"Warning: Could not import file_processing: {e}")

--- a/pages/file_upload.py
+++ b/pages/file_upload.py
@@ -35,11 +35,11 @@ except ImportError:
     html = dcc = dbc = None
 
 try:
-    from components.analytics.file_uploader import (
+    from plugins.file_upload_plugin import (
         create_dual_file_uploader,
         register_dual_upload_callbacks,
+        FileProcessor,
     )
-    from components.analytics.file_processing import FileProcessor
     COMPONENTS_AVAILABLE = True
 except ImportError:
     COMPONENTS_AVAILABLE = False

--- a/plugins/file_upload_plugin.py
+++ b/plugins/file_upload_plugin.py
@@ -1,0 +1,120 @@
+"""
+File Upload Plugin
+Consolidates file uploader UI and processing into a single plugin.
+"""
+
+import logging
+from dataclasses import dataclass
+from typing import Any, Dict, Optional
+
+from core.plugins.protocols import CallbackPluginProtocol, PluginMetadata, PluginPriority
+
+# Reuse existing uploader UI and processing logic
+from components.analytics.file_uploader import (
+    create_dual_file_uploader,
+    register_dual_upload_callbacks,
+)
+from components.analytics.file_processing import FileProcessor
+
+
+@dataclass
+class FileUploadConfig:
+    """Configuration options for the file upload plugin."""
+
+    enabled: bool = True
+    allow_database_connections: bool = False
+    database_uri: Optional[str] = None
+
+
+class FileUploadPlugin(CallbackPluginProtocol):
+    """Plugin providing file upload components and processing."""
+
+    metadata = PluginMetadata(
+        name="FileUploadPlugin",
+        version="1.0",
+        description="Provide CSV/JSON/XLS upload and processing",
+        author="Yosai",
+        priority=PluginPriority.NORMAL,
+    )
+
+    def __init__(self) -> None:
+        self.logger = logging.getLogger(__name__)
+        self.config = FileUploadConfig()
+        self._started = False
+
+    # Plugin lifecycle --------------------------------------------------
+    def load(self, container: Any, config: Dict[str, Any]) -> bool:
+        """Load the plugin and register services."""
+        try:
+            if config:
+                self.configure(config)
+            if container and hasattr(container, "register"):
+                container.register("file_processor", FileProcessor)
+            return True
+        except Exception as exc:
+            self.logger.error("FileUploadPlugin load failed: %s", exc)
+            return False
+
+    def configure(self, config: Dict[str, Any]) -> bool:
+        """Configure plugin settings."""
+        try:
+            for key, value in (config or {}).items():
+                if hasattr(self.config, key):
+                    setattr(self.config, key, value)
+            return True
+        except Exception as exc:
+            self.logger.error("FileUploadPlugin configure failed: %s", exc)
+            return False
+
+    def start(self) -> bool:
+        self._started = True
+        return True
+
+    def stop(self) -> bool:
+        self._started = False
+        return True
+
+    def health_check(self) -> Dict[str, Any]:
+        return {
+            "healthy": True,
+            "started": self._started,
+            "database_connected": bool(self.config.database_uri),
+        }
+
+    # Database ----------------------------------------------------------
+    def connect_database(self, uri: str) -> bool:
+        """Placeholder for future database integration."""
+        self.config.database_uri = uri
+        return True
+
+    # Callback registration --------------------------------------------
+    def register_callbacks(self, app: Any, container: Any) -> bool:
+        try:
+            register_dual_upload_callbacks(app, "file-upload-main")
+            return True
+        except Exception as exc:
+            self.logger.error("Failed to register upload callbacks: %s", exc)
+            return False
+
+
+# Convenience wrappers -------------------------------------------------
+
+def create_file_uploader(upload_id: str = "analytics-file-upload"):
+    """Backward compatible wrapper for dual file uploader."""
+    return create_dual_file_uploader(upload_id)
+
+
+__all__ = [
+    "create_file_uploader",
+    "create_dual_file_uploader",
+    "register_dual_upload_callbacks",
+    "FileProcessor",
+    "FileUploadPlugin",
+    "create_plugin",
+]
+
+
+def create_plugin() -> FileUploadPlugin:
+    """Factory used by the plugin manager."""
+    return FileUploadPlugin()
+


### PR DESCRIPTION
## Summary
- add `FileUploadPlugin` that exposes uploader UI and processing
- wire components and pages to use the new plugin
- update analytics component imports to prefer the plugin

## Testing
- `python -m py_compile plugins/file_upload_plugin.py components/__init__.py components/analytics/__init__.py pages/file_upload.py`
- `pytest -q tests/test_analytics_components.py::test_file_processing -q` *(fails: ModuleNotFoundError: No module named 'dash')*

------
https://chatgpt.com/codex/tasks/task_e_6855f5b9219c8320b9b8fa62f05e2dbd