### PR TITLE
Fix FileUploadPlugin metadata property

### DIFF
--- a/plugins/file_upload_plugin.py
+++ b/plugins/file_upload_plugin.py
@@ -29,13 +29,18 @@ class FileUploadConfig:
 class FileUploadPlugin(CallbackPluginProtocol):
     """Plugin providing file upload components and processing."""
 
-    metadata = PluginMetadata(
+    _metadata = PluginMetadata(
         name="FileUploadPlugin",
         version="1.0",
         description="Provide CSV/JSON/XLS upload and processing",
         author="Yosai",
         priority=PluginPriority.NORMAL,
     )
+
+    @property
+    def metadata(self) -> PluginMetadata:
+        """Return plugin metadata."""
+        return self._metadata
 
     def __init__(self) -> None:
         self.logger = logging.getLogger(__name__)


### PR DESCRIPTION
## Summary
- implement metadata as property for FileUploadPlugin

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'dash')*

------
https://chatgpt.com/codex/tasks/task_e_6855fa0409dc8320be6824875f07f40d