### PR TITLE
Update file info card styles and components

### DIFF
--- a/assets/dashboard.css
+++ b/assets/dashboard.css
@@ -654,3 +654,20 @@ html, body, #root, .dash-app {
   0% { transform: rotate(0deg); }
   100% { transform: rotate(360deg); }
 }
+
+/* File Upload Cards - Following existing signal-card pattern */
+.file-info-card {
+  margin-bottom: 1rem;
+  background-color: #1e2936;
+  border-radius: 6px;
+  color: var(--color-text-primary);
+}
+
+.file-info-card .card-title {
+  color: var(--color-text-primary);
+}
+
+.file-info-card .card-body {
+  color: var(--color-text-primary);
+}
+

--- a/pages/file_upload.py
+++ b/pages/file_upload.py
@@ -67,19 +67,34 @@ def _create_error_alert(message: str):
     return dbc.Alert(message, color="danger", dismissable=True)
 
 
-def _create_file_info_card(df, filename: str):
-    """Create file info card"""
-    if not DASH_AVAILABLE:
-        return f"File: {filename}, Rows: {len(df)}"
+def _create_file_info_card(df, filename: str) -> html.Div:
+    """Create a file information card"""
+    if not DASH_AVAILABLE or df is None:
+        return html.Div(f"File info for {filename}")
 
     return dbc.Card([
-        dbc.CardHeader(f"\U0001F4C4 File: {filename}"),
         dbc.CardBody([
-            html.P(f"\U0001F4CA Rows: {len(df):,}"),
-            html.P(f"\U0001F4CB Columns: {len(df.columns)}"),
-            html.P(f"\U0001F3F7\uFE0F Column Names: {', '.join(df.columns.tolist())}")
+            html.H5(f"\U0001F4CA {filename}", className="card-title"),
+            html.P([
+                html.Strong("Rows: "), f"{len(df):,}", html.Br(),
+                html.Strong("Columns: "), f"{len(df.columns)}", html.Br(),
+                html.Strong("Memory: "), f"{df.memory_usage(deep=True).sum() / 1024:.1f} KB"
+            ])
         ])
-    ], className="mt-3")
+    ], className="mb-3 file-info-card")
+
+
+def _create_file_management_card(file_id: str, filename: str, df) -> html.Div:
+    """Create a file management card"""
+    if not DASH_AVAILABLE:
+        return html.Div(f"Management for {filename}")
+
+    return dbc.Card([
+        dbc.CardBody([
+            html.H6(f"\U0001F4C2 {filename}"),
+            html.P(f"Uploaded successfully - {len(df)} rows"),
+        ])
+    ], className="mb-2 file-info-card")
 
 
 def layout():


### PR DESCRIPTION
## Summary
- style file info cards in dashboard.css
- add file info card and file management card class names

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'dash')*

------
https://chatgpt.com/codex/tasks/task_e_68563096e3488320af7e7d689daf3064