### PR TITLE
Fix service registry import

### DIFF
--- a/app.py
+++ b/app.py
@@ -93,7 +93,7 @@ def create_full_dashboard() -> Optional[Any]:
         container = Container()
 
         # Register component services with container
-        from core.service_registry import configure_container_fixed  # Use your existing service registry
+        from core.service_registry_fixed import configure_container_fixed
         configure_container_fixed(container)
 
         # Create component registry with DI container


### PR DESCRIPTION
## Summary
- fix import of `configure_container_fixed` in `app.py`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_68564e01580c832081a9c16c2f118f74