### PR TITLE
Fix layout manager typing and container setup

### DIFF
--- a/app.py
+++ b/app.py
@@ -93,8 +93,8 @@ def create_full_dashboard() -> Optional[Any]:
         container = Container()
 
         # Register component services with container
-        from core.service_registry_fixed import configure_container_fixed
-        configure_container_fixed(container)
+        from core.service_registry import configure_container_with_yaml
+        configure_container_with_yaml(container)
 
         # Create component registry with DI container
         component_registry = ComponentRegistry(container)

--- a/core/layout_manager.py
+++ b/core/layout_manager.py
@@ -1,17 +1,21 @@
 #!/usr/bin/env python3
 """Layout management integrated with DI container and services"""
-from typing import Any
+from typing import Any, Union
 import logging
 
 logger = logging.getLogger(__name__)
 
-# Safe import of Dash components
+# Safe import of Dash components with proper type handling
 try:
     from dash import html, dcc
     DASH_AVAILABLE = True
+    HtmlType = Any  # html module type
+    DccType = Any   # dcc module type
 except ImportError:
     logger.warning("Dash components not available")
     DASH_AVAILABLE = False
+    HtmlType = None
+    DccType = None
     html = None
     dcc = None
 
@@ -23,11 +27,11 @@ class LayoutManager:
         self.registry = component_registry
         self.container = container
 
-    def create_main_layout(self) -> Any:
+    def create_main_layout(self) -> Union[Any, str]:
         """Create main layout using services from DI container"""
-        if not DASH_AVAILABLE:
+        if not DASH_AVAILABLE or html is None or dcc is None:
             logger.error("Dash components not available")
-            return "Dashboard not available"
+            return "Dashboard not available - Dash components missing"
 
         try:
             # Create layout components
@@ -53,11 +57,14 @@ class LayoutManager:
 
         except Exception as e:
             logger.error(f"Error creating main layout: {e}")
-            return html.Div(f"Layout error: {str(e)}", className="alert alert-danger")
+            if html is not None:
+                return html.Div(f"Layout error: {str(e)}", className="alert alert-danger")
+            else:
+                return f"Layout error: {str(e)}"
 
-    def create_dashboard_content(self) -> Any:
+    def create_dashboard_content(self) -> Union[Any, str]:
         """Create dashboard content using DI container services"""
-        if not DASH_AVAILABLE:
+        if not DASH_AVAILABLE or html is None:
             return "Dashboard content not available"
 
         try:
@@ -65,8 +72,8 @@ class LayoutManager:
             analytics_service = None
             if self.container:
                 try:
-                    analytics_service = self.container.get('analytics_service')
-                except:
+                    analytics_service = self.container.get_optional('analytics_service')
+                except Exception:
                     logger.info("Analytics service not available")
 
             # Create panels using registry (which uses DI container)
@@ -113,8 +120,12 @@ class LayoutManager:
 
         except Exception as e:
             logger.error(f"Error creating dashboard content: {e}")
-            return html.Div([
-                html.H3("🏯 Yōsai Intel Dashboard"),
-                html.P("Dashboard running in safe mode"),
-                html.P(f"Error: {str(e)}")
-            ], className="container")
+            if html is not None:
+                return html.Div([
+                    html.H3("🏯 Yōsai Intel Dashboard"),
+                    html.P("Dashboard running in safe mode"),
+                    html.P(f"Error: {str(e)}")
+                ], className="container")
+            else:
+                return "Dashboard content error"
+


### PR DESCRIPTION
## Summary
- replace layout manager with typed version and safe dash imports
- adjust app container configuration to use YAML-based registry

## Testing
- `python -m py_compile core/layout_manager.py`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_68564f800cb883208ffdda395a33297a