### PR TITLE
Fix duplicate Dash callbacks

### DIFF
--- a/components/door_mapping_modal.py
+++ b/components/door_mapping_modal.py
@@ -320,7 +320,8 @@ def register_door_mapping_modal_callbacks(app):
             Output("door-mapping-current-data-store", "data"),
             [Input("door-mapping-reset-btn", "n_clicks")],
             [State("door-mapping-original-data-store", "data")],
-            prevent_initial_call=True
+            prevent_initial_call=True,
+            allow_duplicate=True
         )
         def reset_to_ai_values(n_clicks, original_data):
             """Reset all values to original AI-generated values"""
@@ -337,7 +338,8 @@ def register_door_mapping_modal_callbacks(app):
                 """,
                 Output("door-mapping-manual-edits-store", "data"),
                 [Input("door-mapping-reset-btn", "n_clicks")],
-                prevent_initial_call=True
+                prevent_initial_call=True,
+                allow_duplicate=True
             )
             
             return original_data


### PR DESCRIPTION
## Summary
- allow duplicate outputs for door mapping callbacks to prevent errors

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_6856bd4390288320bddb4673a85cf6fa