### PR TITLE
Fix duplicate output for door mapping store

### DIFF
--- a/components/door_mapping_modal.py
+++ b/components/door_mapping_modal.py
@@ -260,7 +260,8 @@ def register_door_mapping_modal_callbacks(app):
                 Output("door-mapping-current-data-store", "data")
             ],
             [Input("door-mapping-modal-data-trigger", "data")],
-            prevent_initial_call=True
+            prevent_initial_call=True,
+            allow_duplicate=True
         )
         def update_door_mapping_content(modal_data):
             """Update modal content when new data is provided"""


### PR DESCRIPTION
## Summary
- avoid Dash warning for `door-mapping-current-data-store`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_6856c4b22e008320ba501f9c7e13ce0e