### PR TITLE
Align weak signal feed UI with incident alerts

### DIFF
--- a/assets/css/_signal-panel.css
+++ b/assets/css/_signal-panel.css
@@ -1,1 +1,30 @@
-/* Signal panel styles */
+/* =================================================================== */
+/* _signal-panel.css - Styling for the weak signal panel                */
+/* Mirrors the alert panel styles for a consistent look                 */
+/* =================================================================== */
+
+/* Panel Container */
+.incident-alert-panel {
+  height: 100%;
+  display: flex;
+  flex-direction: column;
+}
+
+/* Header */
+.incident-panel-header {
+  padding: var(--space-4) var(--space-6);
+  border-bottom: 1px solid var(--color-gray-700);
+  background: var(--surface-secondary);
+  flex-shrink: 0;
+  font-size: var(--text-lg);
+  font-weight: var(--font-weight-semibold);
+  color: var(--text-primary);
+  margin: 0;
+}
+
+/* Body */
+.incident-alert-panel .accordion {
+  flex: 1;
+  overflow-y: auto;
+  padding: var(--space-4);
+}

--- a/components/weak_signal_panel.py
+++ b/components/weak_signal_panel.py
@@ -24,54 +24,56 @@ def signal_card(prefix, code, severity, location, description, timestamp):
     )
 
 # Expandable category block
-def category_block(title, signals, category_id):
-    return html.Details(
-        [
-            html.Summary(
-                f"{title} ({len(signals)})",
-                className="signal-summary",
-            ),
-            html.Div(signals, className="signal-category-content"),
-        ],
-        id=category_id,
-        className="signal-category",
+def signal_category_block(title, signals, category_id):
+    """Return an accordion item block for a signal category"""
+    return dbc.AccordionItem(
+        html.Div(signals, className="signal-list"),
+        title=f"{title} ({len(signals)})",
+        item_id=category_id,
     )
 
 
 def layout():
     layout_div = html.Div(
         [
-            html.H4(_l("Weak-Signal Live Feed"), className="panel-header"),
-            category_block(
-                _l("News Scraping"),
-                [
-                    signal_card(
-                        "N",
-                        "0001",
-                        "High",
-                        "Yokohama",
-                        "Foreign actor probing energy facilities",
-                        "25 June 2025",
-                    )
+            html.H4(_l("Weak-Signal Live Feed"), className="incident-panel-header"),
+            dbc.Accordion(
+                children=[
+                    signal_category_block(
+                        _l("News Scraping"),
+                        [
+                            signal_card(
+                                "N",
+                                "0001",
+                                "High",
+                                "Yokohama",
+                                "Foreign actor probing energy facilities",
+                                "25 June 2025",
+                            )
+                        ],
+                        "weak-signal-news",
+                    ),
+                    signal_category_block(
+                        _l("Cross-Location"),
+                        [
+                            signal_card(
+                                "CO",
+                                "0001",
+                                "Medium",
+                                "Tokyo HQ",
+                                "Unusual access pattern detected",
+                                "25 June 2025",
+                            )
+                        ],
+                        "weak-signal-cross-location",
+                    ),
                 ],
-                "weak-signal-news",
-            ),
-            category_block(
-                _l("Cross-Location"),
-                [
-                    signal_card(
-                        "CO",
-                        "0001",
-                        "Medium",
-                        "Tokyo HQ",
-                        "Unusual access pattern detected",
-                        "25 June 2025",
-                    )
-                ],
-                "weak-signal-cross-location",
+                start_collapsed=True,
+                always_open=False,
+                id="weak-signal-accordion",
             ),
         ],
-        className="weak-signal-panel",
+        className="incident-alert-panel",
     )
 
     # JSON SANITIZATION - Convert LazyString objects to regular strings


### PR DESCRIPTION
## Summary
- use an accordion layout in `weak_signal_panel`
- apply panel styling for the weak signal feed

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_6856ca30a52883208fdf94ce31847e36