### PR TITLE
Add modal and dropdown CSS

### DIFF
--- a/assets/dashboard.css
+++ b/assets/dashboard.css
@@ -671,3 +671,262 @@ html, body, #root, .dash-app {
   color: var(--color-text-primary);
 }
 
+/* =================================
+   MODAL AND DROPDOWN FIXES
+   ================================= */
+
+/* Modal base styling */
+.modal-overlay {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background-color: rgba(0, 0, 0, 0.8);
+  z-index: 1050;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.modal {
+  background-color: var(--color-surface);
+  color: var(--color-text-primary);
+  border-radius: 12px;
+  box-shadow: 0 10px 25px rgba(0, 0, 0, 0.3);
+  max-width: 90vw;
+  max-height: 90vh;
+  overflow-y: auto;
+}
+
+.modal--xl {
+  width: 1000px;
+}
+
+.modal__header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 1.5rem;
+  border-bottom: 1px solid var(--color-border);
+  background-color: var(--color-primary);
+}
+
+.modal__title {
+  font-size: 1.25rem;
+  font-weight: bold;
+  color: var(--color-text-primary);
+  margin: 0;
+}
+
+.modal__close {
+  background: none;
+  border: none;
+  color: var(--color-text-tertiary);
+  font-size: 1.5rem;
+  cursor: pointer;
+  padding: 0.25rem;
+  line-height: 1;
+  transition: color 0.3s ease;
+}
+
+.modal__close:hover {
+  color: var(--color-text-primary);
+}
+
+.modal__body {
+  padding: 1.5rem;
+  background-color: var(--color-surface);
+}
+
+.modal__footer {
+  display: flex;
+  justify-content: flex-end;
+  gap: 1rem;
+  padding: 1rem 1.5rem;
+  border-top: 1px solid var(--color-border);
+  background-color: var(--color-surface);
+}
+
+/* Form styling for dark theme */
+.form-group {
+  display: flex;
+  gap: 2rem;
+  margin-bottom: 1.5rem;
+}
+
+.form-field {
+  margin-bottom: 1rem;
+}
+
+.form-label {
+  display: block;
+  color: var(--color-text-primary);
+  font-weight: 600;
+  margin-bottom: 0.5rem;
+  font-size: 0.875rem;
+}
+
+.form-label--required::after {
+  content: " *";
+  color: var(--color-critical);
+}
+
+.form-input {
+  width: 100%;
+  padding: 0.75rem;
+  background-color: var(--color-primary);
+  border: 1px solid var(--color-border);
+  border-radius: 6px;
+  color: var(--color-text-primary);
+  font-size: 0.875rem;
+}
+
+.form-input:focus {
+  outline: none;
+  border-color: var(--color-accent);
+  box-shadow: 0 0 0 3px rgba(59, 130, 246, 0.1);
+}
+
+/* =================================
+   DASH DROPDOWN DARK THEME FIXES
+   ================================= */
+
+/* Fix Dash dropdown styling for dark theme */
+.form-select .Select {
+  background-color: var(--color-primary) !important;
+}
+
+.form-select .Select-control {
+  background-color: var(--color-primary) !important;
+  border-color: var(--color-border) !important;
+  color: var(--color-text-primary) !important;
+}
+
+.form-select .Select-control:hover {
+  border-color: var(--color-accent) !important;
+}
+
+.form-select .Select-control.is-focused {
+  border-color: var(--color-accent) !important;
+  box-shadow: 0 0 0 3px rgba(59, 130, 246, 0.1) !important;
+}
+
+.form-select .Select-placeholder {
+  color: var(--color-text-tertiary) !important;
+}
+
+.form-select .Select-value-label {
+  color: var(--color-text-primary) !important;
+}
+
+.form-select .Select-arrow {
+  border-color: var(--color-text-tertiary) transparent transparent !important;
+}
+
+.form-select .Select-menu-outer {
+  background-color: var(--color-primary) !important;
+  border: 1px solid var(--color-border) !important;
+  box-shadow: 0 4px 6px rgba(0, 0, 0, 0.3) !important;
+}
+
+.form-select .Select-menu {
+  background-color: var(--color-primary) !important;
+}
+
+.form-select .Select-option {
+  background-color: var(--color-primary) !important;
+  color: var(--color-text-primary) !important;
+  padding: 0.75rem !important;
+}
+
+.form-select .Select-option:hover,
+.form-select .Select-option.is-focused {
+  background-color: var(--color-accent) !important;
+  color: white !important;
+}
+
+.form-select .Select-option.is-selected {
+  background-color: var(--color-accent) !important;
+  color: white !important;
+}
+
+/* Alternative CSS targeting for newer Dash versions */
+.form-select .dash-dropdown {
+  background-color: var(--color-primary) !important;
+}
+
+.form-select .dash-dropdown .Select-control {
+  background-color: var(--color-primary) !important;
+  border-color: var(--color-border) !important;
+}
+
+.form-select .dash-dropdown .Select-menu-outer {
+  background-color: var(--color-primary) !important;
+  border: 1px solid var(--color-border) !important;
+}
+
+.form-select .dash-dropdown .Select-option {
+  background-color: var(--color-primary) !important;
+  color: var(--color-text-primary) !important;
+}
+
+.form-select .dash-dropdown .Select-option:hover {
+  background-color: var(--color-accent) !important;
+  color: white !important;
+}
+
+/* Fallback for direct CSS custom properties */
+.form-select div[class*="control"] {
+  background-color: var(--color-primary) !important;
+  border-color: var(--color-border) !important;
+}
+
+.form-select div[class*="menu"] {
+  background-color: var(--color-primary) !important;
+  border: 1px solid var(--color-border) !important;
+}
+
+.form-select div[class*="option"] {
+  background-color: var(--color-primary) !important;
+  color: var(--color-text-primary) !important;
+}
+
+.form-select div[class*="option"]:hover {
+  background-color: var(--color-accent) !important;
+  color: white !important;
+}
+
+.form-select div[class*="singleValue"],
+.form-select div[class*="placeholder"] {
+  color: var(--color-text-primary) !important;
+}
+
+/* Additional fixes for form elements */
+.form-checkbox input[type="checkbox"] {
+  accent-color: var(--color-accent);
+}
+
+.form-checkbox label {
+  color: var(--color-text-primary);
+  margin-left: 0.5rem;
+}
+
+/* Button styling in modal */
+.modal__footer .form-input {
+  background-color: var(--color-accent);
+  color: white;
+  border: none;
+  cursor: pointer;
+  font-weight: 600;
+  transition: background-color 0.3s ease;
+}
+
+.modal__footer .form-input:hover {
+  background-color: var(--color-accent-hover);
+}
+
+.modal__footer .form-input[style*="backgroundColor"] {
+  border: 1px solid var(--color-border);
+}
+


### PR DESCRIPTION
## Summary
- add CSS rules for modals and dropdowns

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_6856d087e3b48320b68edaed49c02c75