### PR TITLE
Fix file upload callbacks

### DIFF
--- a/components/analytics/file_uploader.py
+++ b/components/analytics/file_uploader.py
@@ -97,7 +97,7 @@ def create_dual_file_uploader(upload_id: str = 'analytics-file-upload') -> html.
         return html.Div(f"Upload component error: {e}", className="text-danger")
 
 
-def register_dual_upload_callbacks(app, upload_id: str = 'analytics-file-upload'):
+def register_dual_upload_callbacks(app, upload_id: str = 'upload-data'):
     """Register callbacks for dual upload functionality"""
     try:
         app.clientside_callback(
@@ -180,8 +180,8 @@ def register_dual_upload_callbacks(app, upload_id: str = 'analytics-file-upload'
             Output("door-mapping-modal-data-trigger", "data"),
             Output("door-mapping-modal-trigger", "n_clicks")
         ],
-        [Input(upload_id, "contents")],
-        [State(upload_id, "filename")],
+        [Input('upload-data', "contents")],
+        [State('upload-data', "filename")],
         prevent_initial_call=True
     )
     def trigger_door_mapping_modal(contents, filename):
@@ -376,7 +376,6 @@ def render_column_mapping_panel(header_options, file_name="access_control_data_1
      Output('upload-status', 'children'),
      Output('mapping-verified-status', 'children')],
     [Input('upload-data', 'contents'),
-     Input('close-mapping-modal', 'n_clicks'),
      Input('cancel-mapping', 'n_clicks'),
      Input('verify-mapping', 'n_clicks')],
     [State('upload-data', 'filename'),
@@ -388,7 +387,7 @@ def render_column_mapping_panel(header_options, file_name="access_control_data_1
      State('user-id-storage', 'children')],
     prevent_initial_call=True
 )
-def handle_all_upload_modal_actions(upload_contents, close_clicks, cancel_clicks, verify_clicks,
+def handle_all_upload_modal_actions(upload_contents, cancel_clicks, verify_clicks,
                                   upload_filename, timestamp_col, device_col, user_col,
                                   event_type_col, floor_estimate, user_id):
     """Single callback to handle all upload and modal actions"""
@@ -450,7 +449,7 @@ def handle_all_upload_modal_actions(upload_contents, close_clicks, cancel_clicks
             logger.error(f"Error processing file: {e}")
             error_status = html.Div(f"❌ Error processing file: {str(e)}", className="alert alert-error")
             return dash.no_update, {"display": "none"}, error_status, ""
-    elif trigger_id in ['close-mapping-modal', 'cancel-mapping']:
+    elif trigger_id in ['cancel-mapping']:
         return dash.no_update, {"display": "none"}, dash.no_update, ""
     elif trigger_id == 'verify-mapping' and verify_clicks:
         try:

--- a/components/door_mapping_modal.py
+++ b/components/door_mapping_modal.py
@@ -379,6 +379,18 @@ def register_door_mapping_clientside_callbacks(app):
         logger.error(f"Error registering door mapping clientside callbacks: {e}")
 
 
+# Close button callback for door mapping modal
+@callback(
+    Output("door-mapping-modal-container", "style"),
+    [Input("door-mapping-modal-close-btn", "n_clicks")],
+    prevent_initial_call=True
+)
+def close_door_mapping_modal(close_clicks):
+    """Close the door mapping modal"""
+    if close_clicks:
+        return {"display": "none"}
+    return dash.no_update
+
 # Export the layout function for consistency with other components
 layout = create_door_mapping_modal
 __all__ = [


### PR DESCRIPTION
## Summary
- update file uploader callbacks to remove nonexistent close button id
- update trigger logic for cancel button
- register upload callbacks with correct upload id
- fix door mapping modal trigger callback and add close modal callback

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_6856e532d49c8320a3bc754ac861492c