### PR TITLE
Implement centralized callback registry

### DIFF
--- a/components/__init__.py
+++ b/components/__init__.py
@@ -29,11 +29,7 @@ except ImportError as e:
     SETTINGS_MODAL_AVAILABLE = False
 
 try:
-    from .door_mapping_modal import (
-        create_door_mapping_modal,
-        register_door_mapping_modal_callbacks,
-        register_door_mapping_clientside_callbacks,
-    )
+    from .door_mapping_modal import create_door_mapping_modal, DoorMappingCallbackManager
     DOOR_MAPPING_MODAL_AVAILABLE = True
 except ImportError as e:
     logger.warning(f"Door mapping modal component not available: {e}")
@@ -51,8 +47,7 @@ if SETTINGS_MODAL_AVAILABLE:
 if DOOR_MAPPING_MODAL_AVAILABLE:
     __all__.extend([
         'create_door_mapping_modal',
-        'register_door_mapping_modal_callbacks',
-        'register_door_mapping_clientside_callbacks',
+        'DoorMappingCallbackManager'
     ])
 
 

--- a/components/analytics/file_uploader.py
+++ b/components/analytics/file_uploader.py
@@ -505,9 +505,9 @@ def handle_door_mapping(open_clicks, skip_clicks):
 
     if open_clicks:
         try:
-            from door_mapping_modal import render_door_mapping_modal
+            from components.door_mapping_modal import create_door_mapping_modal
 
-            modal_content = render_door_mapping_modal()
+            modal_content = create_door_mapping_modal()
             return modal_content, {'display': 'block'}
 
         except ImportError:

--- a/core/callback_registry.py
+++ b/core/callback_registry.py
@@ -1,0 +1,89 @@
+"""
+Centralized Callback Registry for Dash Application
+Manages all callbacks in a modular, organized way
+"""
+from dash import callback, Input, Output, State, callback_context, clientside_callback
+import dash
+from typing import Dict, List, Callable, Any
+import logging
+
+logger = logging.getLogger(__name__)
+
+
+class CallbackRegistry:
+    """Central registry for all application callbacks"""
+    
+    def __init__(self, app):
+        self.app = app
+        self.registered_callbacks = {}
+        self.clientside_callbacks = {}
+        
+    def register_callback(self, 
+                         outputs: List,
+                         inputs: List, 
+                         states: List = None,
+                         prevent_initial_call: bool = True,
+                         callback_id: str = None):
+        """Decorator to register callbacks"""
+        def decorator(func: Callable):
+            if callback_id and callback_id in self.registered_callbacks:
+                logger.warning(f"Callback {callback_id} already registered, skipping")
+                return func
+                
+            try:
+                @self.app.callback(
+                    outputs,
+                    inputs,
+                    states or [],
+                    prevent_initial_call=prevent_initial_call
+                )
+                def wrapper(*args, **kwargs):
+                    return func(*args, **kwargs)
+                
+                if callback_id:
+                    self.registered_callbacks[callback_id] = wrapper
+                    logger.debug(f"Registered callback: {callback_id}")
+                    
+                return wrapper
+            except Exception as e:
+                logger.error(f"Failed to register callback {callback_id}: {e}")
+                return func
+        return decorator
+    
+    def register_clientside_callback(self,
+                                   clientside_function: str,
+                                   outputs: List,
+                                   inputs: List,
+                                   states: List = None,
+                                   callback_id: str = None):
+        """Register clientside callbacks"""
+        if callback_id and callback_id in self.clientside_callbacks:
+            logger.warning(f"Clientside callback {callback_id} already registered, skipping")
+            return
+            
+        try:
+            self.app.clientside_callback(
+                clientside_function,
+                outputs,
+                inputs,
+                states or []
+            )
+            
+            if callback_id:
+                self.clientside_callbacks[callback_id] = True
+                logger.debug(f"Registered clientside callback: {callback_id}")
+                
+        except Exception as e:
+            logger.error(f"Failed to register clientside callback {callback_id}: {e}")
+
+
+class ComponentCallbackManager:
+    """Base class for component callback managers"""
+    
+    def __init__(self, callback_registry: CallbackRegistry):
+        self.registry = callback_registry
+        self.component_name = self.__class__.__name__.replace('CallbackManager', '')
+        
+    def register_all(self):
+        """Register all callbacks for this component"""
+        raise NotImplementedError("Subclasses must implement register_all")


### PR DESCRIPTION
## Summary
- add `CallbackRegistry` to manage all callbacks in one place
- simplify and update `door_mapping_modal` with its own callback manager
- wire the registry into the dashboard startup
- export new callback manager in `components/__init__`
- adjust file uploader to use new modal

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_685756ccfb98832087f349dd1806b513