### PR TITLE
Fix navbar callback outputs

### DIFF
--- a/components/door_mapping_modal.py
+++ b/components/door_mapping_modal.py
@@ -155,7 +155,7 @@ class DoorMappingCallbackManager:
     def _register_modal_visibility(self):
         """Register modal visibility callbacks"""
         @self.registry.register_callback(
-            outputs=[Output("door-mapping-modal-overlay", "className")],
+            outputs=Output("door-mapping-modal-overlay", "className"),  # Single output
             inputs=[
                 Input("door-mapping-modal-trigger", "n_clicks"),
                 Input("door-mapping-modal-close-btn", "n_clicks"),
@@ -180,7 +180,7 @@ class DoorMappingCallbackManager:
     def _register_data_updates(self):
         """Register data update callbacks"""
         @self.registry.register_callback(
-            outputs=[Output("door-mapping-current-data-store", "data")],
+            outputs=Output("door-mapping-current-data-store", "data"),  # Single output
             inputs=[
                 Input("door-mapping-modal-data-trigger", "data"),
                 Input("door-mapping-reset-btn", "n_clicks")

--- a/components/settings_callback_manager.py
+++ b/components/settings_callback_manager.py
@@ -22,7 +22,7 @@ class SettingsCallbackManager:
     def _register_modal_visibility(self):
         """Register settings modal visibility callback"""
         @self.registry.register_callback(
-            outputs=[Output("settings-modal-overlay", "className")],
+            outputs=Output("settings-modal-overlay", "className"),  # Single output
             inputs=[
                 Input("navbar-settings-btn", "n_clicks"),
                 Input("settings-modal-close-btn", "n_clicks"),
@@ -46,7 +46,7 @@ class SettingsCallbackManager:
     def _register_settings_navigation(self):
         """Register settings navigation callbacks"""
         @self.registry.register_callback(
-            outputs=[Output("url", "pathname")],
+            outputs=Output("url", "pathname"),  # Single output
             inputs=[
                 Input("settings-critical-doors", "n_clicks"),
                 Input("settings-event-aliases", "n_clicks"),
@@ -59,7 +59,7 @@ class SettingsCallbackManager:
                 Input("settings-ticket-generation", "n_clicks"),
                 Input("settings-user-management", "n_clicks"),
             ],
-            callback_id="settings_navigation",
+            callback_id="settings_navigation"
         )
         def handle_settings_navigation(*args):
             """Handle settings navigation"""

--- a/core/callback_registry.py
+++ b/core/callback_registry.py
@@ -18,9 +18,9 @@ class CallbackRegistry:
         self.registered_callbacks = {}
         self.clientside_callbacks = {}
         
-    def register_callback(self, 
-                         outputs: List,
-                         inputs: List, 
+    def register_callback(self,
+                         outputs,
+                         inputs: List,
                          states: List = None,
                          prevent_initial_call: bool = True,
                          callback_id: str = None):
@@ -52,7 +52,7 @@ class CallbackRegistry:
     
     def register_clientside_callback(self,
                                    clientside_function: str,
-                                   outputs: List,
+                                   outputs,  # Don't specify type - can be single or list
                                    inputs: List,
                                    states: List = None,
                                    callback_id: str = None):
@@ -64,7 +64,7 @@ class CallbackRegistry:
         try:
             self.app.clientside_callback(
                 clientside_function,
-                outputs,
+                outputs,  # Pass as-is
                 inputs,
                 states or []
             )

--- a/core/navigation_manager.py
+++ b/core/navigation_manager.py
@@ -23,7 +23,7 @@ class NavigationCallbackManager:
     def _register_page_routing(self):
         """Register main page routing callback"""
         @self.registry.register_callback(
-            outputs=[Output("page-content", "children")],
+            outputs=Output("page-content", "children"),  # Single output, not list
             inputs=[Input("url", "pathname")],
             prevent_initial_call=False,
             callback_id="main_page_routing"
@@ -58,9 +58,9 @@ class NavigationCallbackManager:
 
     def _register_navbar_callbacks(self):
         """Register navbar-related callbacks"""
-        # Live time update
+        # Live time update - single output, so don't use list wrapper
         @self.registry.register_callback(
-            outputs=[Output("live-time", "children")],
+            outputs=Output("live-time", "children"),  # Single output, not a list
             inputs=[Input("url", "pathname")],
             callback_id="navbar_live_time"
         )
@@ -74,9 +74,9 @@ class NavigationCallbackManager:
                 logger.error(f"Error updating live time: {e}")
                 return "Live: --:--:--"
 
-        # Page context update
+        # Page context update - single output, so don't use list wrapper
         @self.registry.register_callback(
-            outputs=[Output("page-context", "children")],
+            outputs=Output("page-context", "children"),  # Single output, not a list
             inputs=[Input("url", "pathname")],
             callback_id="navbar_page_context"
         )
@@ -88,7 +88,7 @@ class NavigationCallbackManager:
                 "/file-upload": "File Upload – Data Management",
                 "/export": "Export – Report Generation",
                 "/settings": "Settings – System Configuration",
-                "/login": "Login – Authentication",
+                "/login": "Login – Authentication"
             }
             return page_contexts.get(pathname, "Dashboard – Main Operations")
 


### PR DESCRIPTION
## Summary
- fix callback output registration for single vs. multi outputs
- update navigation manager and callback managers to use correct `Output` syntax
- handle clientside callback registration with flexible outputs

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_68575d3741a8832090637a8faa275328