### PR TITLE
Add persistent CSV session storage

### DIFF
--- a/plugins/ai_classification/database/csv_storage.py
+++ b/plugins/ai_classification/database/csv_storage.py
@@ -1,48 +1,226 @@
-"""In-memory CSV storage repository"""
+"""File-based CSV storage repository with persistence"""
 
-from typing import Any, Dict, Optional
+import json
+import logging
+from typing import Any, Dict, Optional, List
+from pathlib import Path
+from datetime import datetime
+
+logger = logging.getLogger(__name__)
 
 
 class CSVStorageRepository:
+    """File-based storage repository for session data persistence"""
+
     def __init__(self, path: str) -> None:
-        self.path = path
-        self.sessions: Dict[str, Any] = {}
+        self.path = Path(path)
+        self.storage_dir = self.path.parent / "session_storage"
+        self.sessions: Dict[str, Any] = {}  # In-memory cache
+        self._ensure_storage_directory()
+
+    def _ensure_storage_directory(self) -> None:
+        """Ensure the storage directory exists"""
+        try:
+            self.storage_dir.mkdir(parents=True, exist_ok=True)
+            logger.info(f"Storage directory ensured: {self.storage_dir}")
+        except Exception as e:
+            logger.error(f"Failed to create storage directory: {e}")
+
+    def _get_session_file_path(self, session_id: str) -> Path:
+        """Get the file path for a session"""
+        return self.storage_dir / f"session_{session_id}.json"
+
+    def _load_session_from_file(self, session_id: str) -> Optional[Dict[str, Any]]:
+        """Load session data from file"""
+        try:
+            file_path = self._get_session_file_path(session_id)
+            if file_path.exists():
+                with open(file_path, "r", encoding="utf-8") as f:
+                    data = json.load(f)
+                    self.sessions[session_id] = data
+                    return data
+        except Exception as e:
+            logger.error(f"Failed to load session {session_id}: {e}")
+        return None
+
+    def _save_session_to_file(self, session_id: str, data: Dict[str, Any]) -> bool:
+        """Save session data to file"""
+        try:
+            file_path = self._get_session_file_path(session_id)
+
+            data_with_meta = {
+                **data,
+                "last_updated": datetime.now().isoformat(),
+                "session_id": session_id,
+            }
+
+            with open(file_path, "w", encoding="utf-8") as f:
+                json.dump(data_with_meta, f, indent=2, ensure_ascii=False)
+
+            self.sessions[session_id] = data_with_meta
+            logger.info(f"Session {session_id} saved to file")
+            return True
+        except Exception as e:
+            logger.error(f"Failed to save session {session_id}: {e}")
+            return False
 
     def initialize(self) -> bool:
-        return True
+        """Initialize the repository and load existing sessions"""
+        try:
+            self._ensure_storage_directory()
+
+            if self.storage_dir.exists():
+                for file_path in self.storage_dir.glob("session_*.json"):
+                    try:
+                        session_id = file_path.stem.replace("session_", "")
+                        self._load_session_from_file(session_id)
+                    except Exception as e:
+                        logger.warning(
+                            f"Failed to load session file {file_path}: {e}"
+                        )
+
+            logger.info(f"Repository initialized with {len(self.sessions)} sessions")
+            return True
+        except Exception as e:
+            logger.error(f"Repository initialization failed: {e}")
+            return False
 
     def store_session_data(self, session_id: str, data: Dict[str, Any]) -> None:
+        """Store session data with file persistence"""
         self.sessions[session_id] = data
+        self._save_session_to_file(session_id, data)
 
     def get_session_data(self, session_id: str) -> Optional[Dict[str, Any]]:
-        return self.sessions.get(session_id)
+        """Get session data from memory or file"""
+        if session_id in self.sessions:
+            return self.sessions[session_id]
+        return self._load_session_from_file(session_id)
+
+    def update_session_data(self, session_id: str, updates: Dict[str, Any]) -> None:
+        """Update existing session data"""
+        current_data = self.get_session_data(session_id) or {}
+        current_data.update(updates)
+        self.store_session_data(session_id, current_data)
 
     # Column mapping
     def store_column_mapping(self, session_id: str, mapping: Dict[str, Any]) -> None:
-        sess = self.sessions.setdefault(session_id, {})
-        sess["column_mapping"] = mapping
+        """Store column mapping data"""
+        self.update_session_data(session_id, {"column_mapping": mapping})
 
     def update_column_mapping(self, session_id: str, mapping: Dict[str, Any]) -> None:
-        sess = self.sessions.setdefault(session_id, {})
-        sess["column_mapping"] = mapping
+        """Update column mapping data"""
+        self.store_column_mapping(session_id, mapping)
 
     def get_column_mapping(self, session_id: str) -> Optional[Dict[str, Any]]:
-        sess = self.sessions.get(session_id)
+        """Get column mapping data"""
+        sess = self.get_session_data(session_id)
         if sess:
             return sess.get("column_mapping")
         return None
 
     # Floor estimation
     def store_floor_estimation(self, session_id: str, data: Dict[str, Any]) -> None:
-        sess = self.sessions.setdefault(session_id, {})
-        sess["floor_estimation"] = data
+        """Store floor estimation data"""
+        self.update_session_data(session_id, {"floor_estimation": data})
+
+    def get_floor_estimation(self, session_id: str) -> Optional[Dict[str, Any]]:
+        """Get floor estimation data"""
+        sess = self.get_session_data(session_id)
+        if sess:
+            return sess.get("floor_estimation")
+        return None
 
     # Entry classification
     def store_entry_classification(self, session_id: str, data: Any) -> None:
-        sess = self.sessions.setdefault(session_id, {})
-        sess["entry_classification"] = data
+        """Store entry classification data"""
+        self.update_session_data(session_id, {"entry_classification": data})
 
-    # Permanent storage (placeholder)
+    def get_entry_classification(self, session_id: str) -> Optional[Any]:
+        """Get entry classification data"""
+        sess = self.get_session_data(session_id)
+        if sess:
+            return sess.get("entry_classification")
+        return None
+
+    # Processed data storage
+    def store_processed_data(self, session_id: str, data: Dict[str, Any]) -> None:
+        """Store cleaned and processed CSV data"""
+        self.update_session_data(session_id, {"processed_data": data})
+
+    def get_processed_data(self, session_id: str) -> Optional[Dict[str, Any]]:
+        """Get processed CSV data"""
+        sess = self.get_session_data(session_id)
+        if sess:
+            return sess.get("processed_data")
+        return None
+
+    # Session management
+    def list_sessions(self) -> List[str]:
+        """List all available session IDs"""
+        return list(self.sessions.keys())
+
+    def delete_session(self, session_id: str) -> bool:
+        """Delete a session and its file"""
+        try:
+            if session_id in self.sessions:
+                del self.sessions[session_id]
+
+            file_path = self._get_session_file_path(session_id)
+            if file_path.exists():
+                file_path.unlink()
+
+            logger.info(f"Session {session_id} deleted")
+            return True
+        except Exception as e:
+            logger.error(f"Failed to delete session {session_id}: {e}")
+            return False
+
+    def cleanup_old_sessions(self, max_age_days: int = 7) -> int:
+        """Clean up old session files"""
+        cleaned = 0
+        try:
+            cutoff_time = datetime.now().timestamp() - (max_age_days * 24 * 3600)
+
+            for file_path in self.storage_dir.glob("session_*.json"):
+                if file_path.stat().st_mtime < cutoff_time:
+                    session_id = file_path.stem.replace("session_", "")
+                    if self.delete_session(session_id):
+                        cleaned += 1
+
+            logger.info(f"Cleaned up {cleaned} old sessions")
+        except Exception as e:
+            logger.error(f"Session cleanup failed: {e}")
+
+        return cleaned
+
+    # Permanent storage
     def save_permanent_data(self, session_id: str, client_id: str) -> bool:
-        return True
+        """Save session data permanently with client association"""
+        try:
+            session_data = self.get_session_data(session_id)
+            if not session_data:
+                return False
 
+            permanent_dir = self.storage_dir / "permanent" / client_id
+            permanent_dir.mkdir(parents=True, exist_ok=True)
+
+            timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
+            permanent_file = permanent_dir / f"data_{timestamp}.json"
+
+            permanent_data = {
+                **session_data,
+                "client_id": client_id,
+                "original_session_id": session_id,
+                "saved_at": datetime.now().isoformat(),
+            }
+
+            with open(permanent_file, "w", encoding="utf-8") as f:
+                json.dump(permanent_data, f, indent=2, ensure_ascii=False)
+
+            logger.info(
+                f"Session {session_id} saved permanently for client {client_id}"
+            )
+            return True
+        except Exception as e:
+            logger.error(f"Failed to save permanent data: {e}")
+            return False

--- a/utils/session_manager.py
+++ b/utils/session_manager.py
@@ -1,0 +1,80 @@
+"""Session management utilities for persistent data"""
+
+import logging
+from typing import Optional, Dict, Any, List
+from plugins.ai_classification.plugin import AIClassificationPlugin
+
+logger = logging.getLogger(__name__)
+
+
+class SessionManager:
+    """Manage session data persistence and retrieval"""
+
+    def __init__(self):
+        self.ai_plugin = None
+        self._initialize_plugin()
+
+    def _initialize_plugin(self):
+        """Initialize AI plugin for data access"""
+        try:
+            self.ai_plugin = AIClassificationPlugin()
+            self.ai_plugin.start()
+        except Exception as e:
+            logger.error(f"Failed to initialize AI plugin: {e}")
+
+    def get_session_data(self, session_id: str) -> Optional[Dict[str, Any]]:
+        """Get all data for a session"""
+        if not self.ai_plugin:
+            return None
+        try:
+            return self.ai_plugin.get_session_data(session_id)
+        except Exception as e:
+            logger.error(f"Failed to get session data: {e}")
+            return None
+
+    def get_processed_data(self, session_id: str) -> Optional[Dict[str, Any]]:
+        """Get processed CSV data for a session"""
+        if not self.ai_plugin or not self.ai_plugin.csv_repository:
+            return None
+        try:
+            return self.ai_plugin.csv_repository.get_processed_data(session_id)
+        except Exception as e:
+            logger.error(f"Failed to get processed data: {e}")
+            return None
+
+    def list_recent_sessions(self, limit: int = 10) -> List[Dict[str, Any]]:
+        """List recent sessions with metadata"""
+        if not self.ai_plugin or not self.ai_plugin.csv_repository:
+            return []
+        try:
+            session_ids = self.ai_plugin.csv_repository.list_sessions()
+            sessions = []
+            for session_id in session_ids[-limit:]:
+                session_data = self.get_session_data(session_id)
+                if session_data:
+                    processed_data = session_data.get('processed_data', {})
+                    sessions.append({
+                        'session_id': session_id,
+                        'filename': processed_data.get('filename', 'Unknown'),
+                        'upload_time': processed_data.get('upload_timestamp', ''),
+                        'row_count': processed_data.get('row_count', 0),
+                        'headers': processed_data.get('headers', [])
+                    })
+            return sorted(sessions, key=lambda x: x['upload_time'], reverse=True)
+        except Exception as e:
+            logger.error(f"Failed to list sessions: {e}")
+            return []
+
+    def cleanup_old_sessions(self, max_age_days: int = 7) -> int:
+        """Clean up old session data"""
+        if not self.ai_plugin or not self.ai_plugin.csv_repository:
+            return 0
+        try:
+            return self.ai_plugin.csv_repository.cleanup_old_sessions(max_age_days)
+        except Exception as e:
+            logger.error(f"Failed to cleanup sessions: {e}")
+            return 0
+
+
+# Global session manager instance
+session_manager = SessionManager()


### PR DESCRIPTION
## Summary
- implement file-based CSVStorageRepository with session persistence
- persist processed data in file upload callback
- add datetime import for persistence logging
- provide a SessionManager utility for accessing saved sessions

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_68578db235ec8320a67fc002e207e18b