### PR TITLE
Fix Dash imports and update type hints

### DIFF
--- a/app.py
+++ b/app.py
@@ -43,10 +43,10 @@ logging.basicConfig(
 logger = logging.getLogger(__name__)
 
 
-def create_full_dashboard():
+def create_full_dashboard() -> "Dash":
     """Create the complete dashboard application with centralized callbacks"""
     try:
-        from dash import Dash
+        from dash.dash import Dash
         import dash_bootstrap_components as dbc
 
         class YosaiDash(Dash):
@@ -206,7 +206,7 @@ def main() -> None:
 # -------------------------------------------------------------------------
 # WSGI helpers
 
-def get_app() -> Optional[Any]:
+def get_app() -> Optional["Dash"]:
     """Return the Dash app instance for WSGI servers."""
     try:
         app = create_full_dashboard()


### PR DESCRIPTION
## Summary
- import `Dash` from `dash.dash`
- annotate Dash return types for `create_full_dashboard` and `get_app`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_6857f430aea48320bc3c3d0f5f37b71e