### PR TITLE
Fix door mapping modal trigger

### DIFF
--- a/pages/file_upload.py
+++ b/pages/file_upload.py
@@ -132,8 +132,8 @@ def layout():
         html.Div(id='door-mapping-modal', style={'display': 'none'}),
 
         # Additional required elements for next steps
-        html.Button("Proceed to Door Mapping", 
-                   id="open-door-mapping", 
+        html.Button("Proceed to Door Mapping",
+                   id="door-mapping-modal-trigger",
                    className="btn btn-primary mt-3 mr-2",
                    style={"display": "none"}),
         html.Button("Skip Door Mapping", 


### PR DESCRIPTION
## Summary
- wire up door mapping modal trigger button to new modal manager
- forward door mapping data via `door-mapping-modal-data-trigger`

## Testing
- `black --check components/analytics/file_uploader.py pages/file_upload.py`
- `flake8 components/analytics/file_uploader.py pages/file_upload.py` *(fails: command not found)*
- `mypy components/analytics/file_uploader.py pages/file_upload.py` *(fails: found 239 errors)*
- `bandit -r components/analytics/file_uploader.py pages/file_upload.py` *(fails: command not found)*
- `safety check` *(fails: command not found)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*


------
https://chatgpt.com/codex/tasks/task_e_6858af62e3e48320a7cbf80160b4eeb4