### PR TITLE
Fix callback output length

### DIFF
--- a/components/analytics/file_uploader.py
+++ b/components/analytics/file_uploader.py
@@ -422,7 +422,7 @@ def handle_all_upload_modal_actions(upload_contents, cancel_clicks, verify_click
                 no_update, no_update, no_update, no_update, no_update, no_update,
                 no_update, no_update, no_update, no_update, no_update,
                 no_update, no_update, no_update, no_update,
-                no_update, no_update, no_update, no_update,
+                no_update,
                 success_msg,
                 success_msg,
                 file_store_data or {},


### PR DESCRIPTION
## Summary
- fix mismatch between callback outputs and returned values in the file upload modal

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_6858c88049bc832082b31691fb33bbe3