### PR TITLE
Center verify column in door mapping popup

### DIFF
--- a/assets/door_mapping_styles.css
+++ b/assets/door_mapping_styles.css
@@ -127,3 +127,8 @@
     margin-left: 8px !important;
     display: inline-block !important;
 }
+
+/* Center alignment for verify column */
+.verify-column {
+    text-align: center !important;
+}

--- a/components/analytics/file_uploader.py
+++ b/components/analytics/file_uploader.py
@@ -747,11 +747,11 @@ def create_door_mapping_modal_with_data(devices, device_column):
             # AI Confidence
             html.Td([
                 html.Div([
-                    html.Span(f"{ai_attributes['confidence']}%", 
+                    html.Span(f"{ai_attributes['confidence']}%",
                              className="text-sm font-medium"),
                     html.Div("AI Confidence", className="text-xs text-gray-500")
                 ], className="text-center")
-            ], className="px-4 py-3"),
+            ], className="px-4 py-3 text-center verify-column"),
 
         ], className="border-b hover:bg-gray-50", id=f"device-row-{i}"))
 
@@ -786,7 +786,7 @@ def create_door_mapping_modal_with_data(devices, device_column):
                                     html.Th("Door Type", className="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider"),
                                     html.Th("Critical", className="px-4 py-3 text-center text-xs font-medium text-gray-500 uppercase tracking-wider"),
                                     html.Th("Security Level", className="px-4 py-3 text-center text-xs font-medium text-gray-500 uppercase tracking-wider"),
-                                    html.Th("AI Confidence", className="px-4 py-3 text-center text-xs font-medium text-gray-500 uppercase tracking-wider"),
+                                    html.Th("AI Confidence", className="px-4 py-3 text-center text-xs font-medium text-gray-500 uppercase tracking-wider verify-column"),
                                 ])
                             ], className="bg-gray-50"),
 


### PR DESCRIPTION
## Summary
- center the AI Confidence column in the door mapping modal
- add styling for a generic `.verify-column` class

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_6858e0797758832085037ade689750a8