### PR TITLE
Fix app not defined error in file uploader callbacks

### DIFF
--- a/components/analytics/file_uploader.py
+++ b/components/analytics/file_uploader.py
@@ -227,7 +227,7 @@ def render_column_mapping_panel(
     )
 
 
-@app.callback(
+@callback(
     [
         Output("column-mapping-modal", "style"),
         Output("modal-file-info", "children"),


### PR DESCRIPTION
## Summary
- avoid referencing global `app` in `file_uploader.py`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_685914dade648320b2ce9eadf41ab443