### PR TITLE
Fix AccessEvent import

### DIFF
--- a/models/entities.py
+++ b/models/entities.py
@@ -8,6 +8,7 @@ from datetime import datetime
 from typing import Dict, List, Any, Optional, Tuple
 from utils.result_types import Result, success, failure
 from .enums import DoorType
+from .events import AccessEvent
 
 @dataclass(frozen=True)
 class Person:
@@ -130,3 +131,11 @@ class Facility:
             'is_active': self.is_active,
             'created_at': self.created_at
         }
+
+# Re-export AccessEvent for backwards compatibility
+__all__ = [
+    'Person',
+    'Door',
+    'Facility',
+    'AccessEvent',
+]


### PR DESCRIPTION
## Summary
- re-export `AccessEvent` in `models.entities` to satisfy imports

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*
- `python3 app.py` *(fails: No module named 'dash')*

------
https://chatgpt.com/codex/tasks/task_e_68591edec7808320b4971455b2affab9