### PR TITLE
Implement ServiceResult-based analytics service

### DIFF
--- a/core/service_container.py
+++ b/core/service_container.py
@@ -80,8 +80,10 @@ def configure_services() -> None:
     
     # Register analytics service
     from services.analytics_service import create_analytics_service
-    container.register_singleton('analytics_service', 
-                                lambda: create_analytics_service(container.get('database')))
+    container.register_singleton(
+        'analytics_service',
+        lambda: create_analytics_service(None, container.get('database')),
+    )
     
     # Register file processor
     from services.file_processor_service import FileProcessorService

--- a/tests/test_service_isolation.py
+++ b/tests/test_service_isolation.py
@@ -56,11 +56,13 @@ class TestAnalyticsService:
         
         service = AnalyticsService()
         result = service.analyze_access_patterns(self.sample_data)
-        
-        assert 'total_events' in result
-        assert result['total_events'] == 3
-        assert 'access_patterns' in result
-        assert 'unique_users' in result
+
+        assert result.success
+        data = result.data
+        assert 'total_events' in data
+        assert data['total_events'] == 3
+        assert 'access_patterns' in data
+        assert 'unique_users' in data
     
     def test_anomaly_detection(self):
         """Test anomaly detection in isolation"""
@@ -68,8 +70,10 @@ class TestAnalyticsService:
         
         service = AnalyticsService()
         events = self.sample_data.to_dict('records')
-        anomalies = service.detect_anomalies(events)
-        
+        result = service.detect_anomalies(events)
+
+        assert result.success
+        anomalies = result.data
         assert isinstance(anomalies, list)
 
 class TestServiceContainer:


### PR DESCRIPTION
## Summary
- implement AnalyticsConfig dataclass and ServiceResult-aware analytics service
- return ServiceResult from analytics methods and expose analyze_data
- adjust service container registration and update isolation tests

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_6859335c9188832097c2b33b0fedaf4d