### PR TITLE
Fix dash imports

### DIFF
--- a/pages/deep_analytics.py
+++ b/pages/deep_analytics.py
@@ -14,7 +14,8 @@ def safe_text(text):
 
 # Safe imports with fallbacks
 try:
-    from dash import html, dcc, Input, Output, State, callback
+    from dash import html, dcc, callback
+    from dash.dependencies import Input, Output, State
     import dash_bootstrap_components as dbc
     DASH_AVAILABLE = True
 except ImportError:


### PR DESCRIPTION
## Summary
- fix dash imports in `deep_analytics.py`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_68597e4eefe08320897b99a717756b4c