### PR TITLE
Fix white-on-white modal text

### DIFF
--- a/components/analytics/file_uploader.py
+++ b/components/analytics/file_uploader.py
@@ -771,6 +771,7 @@ def create_error_modal(title, message):
                             ),
                         ],
                         className="bg-white p-6 rounded-lg max-w-md",
+                        **{"data-theme": "light"},
                     )
                 ],
                 className="fixed inset-0 bg-black bg-opacity-50 z-50 flex items-center justify-center p-4",
@@ -971,7 +972,9 @@ def create_door_mapping_modal_with_data(devices, device_column):
                                                     ),
                                                     # Table body
                                                     html.Tbody(
-                                                        device_rows, className="bg-white divide-y divide-gray-200"
+                                                        device_rows,
+                                                        className="bg-white divide-y divide-gray-200",
+                                                        **{"data-theme": "light"}
                                                     ),
                                                 ],
                                                 className="min-w-full divide-y divide-gray-200",
@@ -1021,6 +1024,7 @@ def create_door_mapping_modal_with_data(devices, device_column):
                             ),
                         ],
                         className="bg-white rounded-lg max-w-6xl w-full max-h-screen overflow-hidden shadow-xl",
+                        **{"data-theme": "light"},
                     )
                 ],
                 className="fixed inset-0 bg-black bg-opacity-50 z-50 flex items-center justify-center p-4 overflow-auto",

--- a/pages/file_upload.py
+++ b/pages/file_upload.py
@@ -125,7 +125,8 @@ def layout():
                                    className="px-4 py-2 bg-blue-500 text-white rounded hover:bg-blue-600")
                     ], className="flex justify-end")
 
-                ], className="bg-white p-6 rounded-lg max-w-2xl w-full max-h-[90vh] overflow-y-auto")
+                ], className="bg-white p-6 rounded-lg max-w-2xl w-full max-h-[90vh] overflow-y-auto",
+                   **{"data-theme": "light"})
             ], className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50",
                style={"display": "none"}, id="column-mapping-modal-overlay")
         ]),


### PR DESCRIPTION
## Summary
- ensure modals with white backgrounds use the light theme

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_68597bd5620883208246b374e6379ad1