### PR TITLE
Fix dash imports in login page

### DIFF
--- a/pages/login.py
+++ b/pages/login.py
@@ -2,7 +2,8 @@
 """Login page component"""
 
 import dash_bootstrap_components as dbc
-from dash import html, dcc, callback, Output, Input, State
+from dash import html, dcc
+from dash.dependencies import Output, Input, State
 from core.plugins.decorators import safe_callback
 
 


### PR DESCRIPTION
## Summary
- stop using private dash imports

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_685a0bd3d5848320a548acdb0c7b068d