### PR TITLE
Add card text color fixes to CSS

### DIFF
--- a/assets/dashboard.css
+++ b/assets/dashboard.css
@@ -1434,3 +1434,42 @@ td, th {
 .upload-box * {
   color: #ffffff !important;
 }
+
+/* CARD BODY TEXT FIXES */
+
+.card-body {
+  color: #ffffff !important;
+}
+
+.card-title {
+  color: #ffffff !important;
+}
+
+.card-text {
+  color: #f1f5f9 !important;
+}
+
+.file-info-card .card-body {
+  color: #ffffff !important;
+}
+
+.file-info-card .card-title {
+  color: #ffffff !important;
+}
+
+.card-header {
+  color: #ffffff !important;
+}
+
+.card .card-body * {
+  color: #ffffff !important;
+}
+
+.card strong,
+.card b {
+  color: #ffffff !important;
+}
+
+.card .text-muted {
+  color: #e2e8f0 !important;
+}


### PR DESCRIPTION
## Summary
- update dashboard.css with card text color overrides

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_685a186bcc9883209368a1686319d1f3