### PR TITLE
Add database compatibility package

### DIFF
--- a/database/__init__.py
+++ b/database/__init__.py
@@ -1,0 +1,7 @@
+"""Database module - compatibility layer for existing app.py"""
+
+# Import from your existing config/database_manager.py
+from config.database_manager import DatabaseManager, MockDatabaseConnection
+
+# Re-export for compatibility
+__all__ = ['DatabaseManager', 'MockDatabaseConnection']

--- a/database/connection.py
+++ b/database/connection.py
@@ -1,0 +1,43 @@
+"""Database connection - compatible with existing codebase"""
+
+import pandas as pd
+from typing import Optional, Protocol
+from config.database_manager import DatabaseManager, MockDatabaseConnection
+
+
+class DatabaseConnection(Protocol):
+    """Database connection protocol"""
+
+    def execute_query(self, query: str, params: Optional[tuple] = None) -> pd.DataFrame:
+        """Execute SELECT query and return DataFrame"""
+        ...
+
+    def execute_command(self, command: str, params: Optional[tuple] = None) -> int:
+        """Execute INSERT/UPDATE/DELETE and return affected rows"""
+        ...
+
+    def health_check(self) -> bool:
+        """Check if database is accessible"""
+        ...
+
+
+def create_database_connection() -> DatabaseConnection:
+    """Create database connection using existing DatabaseManager"""
+    # Use your existing database manager
+    from config.yaml_config import get_configuration_manager
+
+    config_manager = get_configuration_manager()
+    db_config = config_manager.get_database_config()
+
+    # Create database manager with existing config
+    db_manager = DatabaseManager(
+        db_type=db_config.type,
+        connection_string=getattr(db_config, 'connection_string', ''),
+        **db_config.__dict__
+    )
+
+    return db_manager.get_connection()
+
+
+# For compatibility with existing imports
+__all__ = ['DatabaseConnection', 'create_database_connection', 'DatabaseManager', 'MockDatabaseConnection']


### PR DESCRIPTION
## Summary
- add minimal `database` package as a wrapper over `config.database_manager`
- expose `DatabaseConnection` protocol and helper for creating a database connection

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_685a21fc5e588320a9df5a2da9f04591