### PR TITLE
Enhance file upload page with AI uploader and CSS

### DIFF
--- a/assets/file_uploader.css
+++ b/assets/file_uploader.css
@@ -1,0 +1,71 @@
+/* File Uploader and Column Mapping Styles */
+
+.column-mapping-modal {
+    position: fixed;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    background-color: rgba(0, 0, 0, 0.5);
+    z-index: 1000;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+}
+
+.column-mapping-content {
+    background: white;
+    border-radius: 8px;
+    padding: 24px;
+    max-width: 600px;
+    width: 90%;
+    max-height: 80vh;
+    overflow-y: auto;
+    box-shadow: 0 10px 25px rgba(0, 0, 0, 0.2);
+}
+
+.upload-zone {
+    border: 2px dashed #ccc;
+    border-radius: 10px;
+    padding: 40px;
+    text-align: center;
+    transition: border-color 0.3s ease;
+}
+
+.upload-zone:hover {
+    border-color: #007bff;
+    background-color: #f8f9fa;
+}
+
+.ai-confidence-badge {
+    display: inline-block;
+    padding: 2px 8px;
+    border-radius: 12px;
+    font-size: 0.75rem;
+    font-weight: bold;
+    margin-left: 8px;
+}
+
+.confidence-high {
+    background-color: #d4edda;
+    color: #155724;
+}
+
+.confidence-medium {
+    background-color: #fff3cd;
+    color: #856404;
+}
+
+.confidence-low {
+    background-color: #f8d7da;
+    color: #721c24;
+}
+
+.debug-panel {
+    background-color: #f8f9fa;
+    border: 1px solid #dee2e6;
+    border-radius: 4px;
+    padding: 12px;
+    margin-top: 16px;
+    font-size: 0.875rem;
+}

--- a/core/app_factory.py
+++ b/core/app_factory.py
@@ -19,18 +19,18 @@ def create_app() -> dash.Dash:
             external_stylesheets=[dbc.themes.BOOTSTRAP],
             suppress_callback_exceptions=True
         )
-
+        
         app.title = "Yōsai Intel Dashboard"
-
+        
         # Set main layout with navigation
         app.layout = create_main_layout()
-
+        
         # Register all callbacks
         register_all_callbacks(app)
-
+        
         logger.info("✅ Complete Dash application created successfully")
         return app
-
+        
     except Exception as e:
         logger.error(f"Failed to create application: {e}")
         raise
@@ -41,13 +41,13 @@ def create_main_layout():
     try:
         return html.Div([
             dcc.Location(id='url', refresh=False),
-
+            
             # Navigation bar
             create_navigation_bar(),
-
+            
             # Main content area
             html.Div(id='page-content', className="main-content"),
-
+            
             # Global stores
             dcc.Store(id='global-data-store', data={}),
             dcc.Store(id='user-session-store', data={}),
@@ -67,19 +67,19 @@ def create_navigation_bar():
                     html.Span("🏯 ", className="me-2"),
                     "Yōsai Intel Dashboard"
                 ], href="/", className="navbar-brand"),
-
+                
                 # Navigation links
                 dbc.Nav([
                     dbc.NavItem(dbc.NavLink("Dashboard", href="/", active="exact")),
                     dbc.NavItem(dbc.NavLink("File Upload", href="/file-upload", active="exact")),
                     dbc.NavItem(dbc.NavLink("Analytics", href="/analytics", active="exact")),
                 ], className="ms-auto", navbar=True),
-
+                
                 # Live time display
                 html.Span(id="live-time", className="navbar-text text-light ms-3"),
             ], fluid=True)
         ], color="dark", dark=True, className="mb-4")
-
+    
     except Exception as e:
         logger.error(f"Error creating navigation bar: {e}")
         return html.Div("Navigation error")
@@ -107,7 +107,7 @@ def register_all_callbacks(app):
             except Exception as e:
                 logger.error(f"Error routing to {pathname}: {e}")
                 return create_error_page(f"Error loading page: {str(e)}")
-
+        
         # Live time callback
         @app.callback(
             Output('live-time', 'children'),
@@ -120,14 +120,14 @@ def register_all_callbacks(app):
                 return f"Live: {datetime.now().strftime('%H:%M:%S')}"
             except Exception:
                 return "Live: --:--:--"
-
+        
         # Register page-specific callbacks
         register_dashboard_callbacks(app)
         register_file_upload_callbacks(app)
         register_analytics_callbacks(app)
-
+        
         logger.info("All callbacks registered successfully")
-
+        
     except Exception as e:
         logger.error(f"Error registering callbacks: {e}")
 
@@ -142,7 +142,7 @@ def create_dashboard_page():
                     html.Hr(),
                 ])
             ]),
-
+            
             # Dashboard content
             dbc.Row([
                 dbc.Col([
@@ -181,7 +181,7 @@ def create_dashboard_page():
                     ])
                 ])
             ]),
-
+            
             # Quick actions
             dbc.Row([
                 dbc.Col([
@@ -198,74 +198,85 @@ def create_dashboard_page():
                 ], className="mt-4")
             ])
         ], fluid=True)
-
+        
     except Exception as e:
         logger.error(f"Error creating dashboard: {e}")
         return create_error_page("Dashboard error")
 
 
 def create_file_upload_page():
-    """Create file upload page"""
+    """Create file upload page with AI column mapping"""
     try:
-        return dbc.Container([
-            dbc.Row([
-                dbc.Col([
-                    html.H1("📂 File Upload & Processing", className="text-center mb-4"),
-                    html.P("Upload CSV, JSON, and Excel files for security analytics processing",
-                           className="text-center text-muted mb-4"),
-                ])
-            ]),
+        # Import the actual file upload component
+        from components.analytics.file_uploader import create_dual_file_uploader
+        
+        return html.Div([
+            html.Div([
+                html.H1("🏯 File Upload & Processing", className="text-3xl font-bold mb-4"),
+                html.P(
+                    "Upload CSV, JSON, and Excel files for security analytics processing",
+                    className="text-lg text-gray-600 mb-8",
+                ),
+            ], className="text-center mb-8"),
 
-            # Upload area
-            dbc.Row([
-                dbc.Col([
-                    dbc.Card([
-                        dbc.CardHeader("📤 Upload Files"),
-                        dbc.CardBody([
-                            dcc.Upload(
-                                id='upload-data',
-                                children=html.Div([
-                                    html.I(className="fas fa-cloud-upload-alt fa-3x mb-3"),
-                                    html.H4("Drag and Drop or Click to Upload"),
-                                    html.P("Supports CSV, JSON, Excel files")
-                                ], className="text-center p-4"),
-                                style={
-                                    'width': '100%',
-                                    'height': '200px',
-                                    'lineHeight': '200px',
-                                    'borderWidth': '2px',
-                                    'borderStyle': 'dashed',
-                                    'borderRadius': '10px',
-                                    'borderColor': '#ccc',
-                                    'textAlign': 'center',
-                                    'margin': '10px'
-                                },
-                                multiple=True
-                            ),
-                            html.Div(id='upload-output'),
-                            html.Div(id='upload-status-message', className="mt-3")
-                        ])
-                    ])
-                ])
-            ]),
+            # Use the real dual file uploader with AI column mapping
+            create_dual_file_uploader('upload-data'),
 
-            # AI Column Mapping
-            dbc.Row([
-                dbc.Col([
-                    dbc.Card([
-                        dbc.CardHeader("🤖 AI Column Mapping"),
-                        dbc.CardBody([
-                            html.P("AI-powered column detection will appear here after file upload."),
-                            html.Div(id='column-mapping-area')
-                        ])
-                    ])
-                ], className="mt-4")
-            ])
-        ], fluid=True)
-
+            html.Div(id='upload-status-message', className="mt-6"),
+        ])
+        
+    except ImportError as e:
+        logger.warning(f"Advanced file uploader not available: {e}")
+        # Fallback to simple uploader
+        return create_simple_file_upload_page()
     except Exception as e:
         logger.error(f"Error creating file upload page: {e}")
         return create_error_page("File upload page error")
+
+
+def create_simple_file_upload_page():
+    """Fallback simple file upload page"""
+    return dbc.Container([
+        dbc.Row([
+            dbc.Col([
+                html.H1("📂 File Upload & Processing", className="text-center mb-4"),
+                html.P("Upload CSV, JSON, and Excel files for security analytics processing", 
+                       className="text-center text-muted mb-4"),
+            ])
+        ]),
+        
+        # Simple upload area
+        dbc.Row([
+            dbc.Col([
+                dbc.Card([
+                    dbc.CardHeader("📤 Upload Files"),
+                    dbc.CardBody([
+                        dcc.Upload(
+                            id='upload-data',
+                            children=html.Div([
+                                html.H4("Drag and Drop or Click to Upload"),
+                                html.P("Supports CSV, JSON, Excel files")
+                            ], className="text-center p-4"),
+                            style={
+                                'width': '100%',
+                                'height': '200px',
+                                'lineHeight': '200px',
+                                'borderWidth': '2px',
+                                'borderStyle': 'dashed',
+                                'borderRadius': '10px',
+                                'borderColor': '#ccc',
+                                'textAlign': 'center',
+                                'margin': '10px'
+                            },
+                            multiple=True
+                        ),
+                        html.Div(id='upload-output'),
+                        html.Div(id='upload-status-message', className="mt-3")
+                    ])
+                ])
+            ])
+        ])
+    ], fluid=True)
 
 
 def create_analytics_page():
@@ -275,11 +286,11 @@ def create_analytics_page():
             dbc.Row([
                 dbc.Col([
                     html.H1("📊 Deep Analytics", className="text-center mb-4"),
-                    html.P("Advanced data analysis and visualization for security intelligence",
+                    html.P("Advanced data analysis and visualization for security intelligence", 
                            className="text-center text-muted mb-4"),
                 ])
             ]),
-
+            
             # Data source selection
             dbc.Row([
                 dbc.Col([
@@ -317,7 +328,7 @@ def create_analytics_page():
                             ]),
                             html.Hr(),
                             dbc.Button(
-                                "Generate Analytics",
+                                "Generate Analytics", 
                                 id="generate-analytics-btn",
                                 color="primary",
                                 className="mt-2"
@@ -326,7 +337,7 @@ def create_analytics_page():
                     ])
                 ])
             ]),
-
+            
             # Analytics display area
             dbc.Row([
                 dbc.Col([
@@ -334,7 +345,7 @@ def create_analytics_page():
                 ])
             ])
         ], fluid=True)
-
+        
     except Exception as e:
         logger.error(f"Error creating analytics page: {e}")
         return create_error_page("Analytics page error")
@@ -378,8 +389,16 @@ def register_dashboard_callbacks(app):
 
 
 def register_file_upload_callbacks(app):
-    """Register file upload callbacks"""
+    """Register file upload callbacks - only for fallback uploader"""
     try:
+        # Check if advanced uploader is available
+        try:
+            from components.analytics.file_uploader import create_dual_file_uploader
+            logger.info("Advanced file uploader available - skipping basic callbacks")
+            return  # Advanced uploader has its own callbacks
+        except ImportError:
+            logger.info("Using fallback file upload callbacks")
+            
         @app.callback(
             Output('upload-output', 'children'),
             Input('upload-data', 'contents'),
@@ -387,7 +406,7 @@ def register_file_upload_callbacks(app):
         )
         def update_output(contents):
             if contents is not None:
-                return dbc.Alert("✅ File uploaded successfully!", color="success")
+                return dbc.Alert("✅ File uploaded successfully! (Basic mode)", color="success")
             return ""
     except Exception as e:
         logger.error(f"Error registering upload callbacks: {e}")


### PR DESCRIPTION
## Summary
- swap the basic uploader for the AI-enabled dual uploader
- register upload callbacks only when the advanced uploader is unavailable
- add CSS styles for the column mapping modal

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_685a30a3940c8320b29e1fae4592e9b2