### PR TITLE
Fix manual mapping not appearing for uppercase file extensions

### DIFF
--- a/components/analytics/file_processing.py
+++ b/components/analytics/file_processing.py
@@ -53,11 +53,13 @@ class FileProcessor:
             except Exception:
                 return None
             
-            if filename.endswith('.csv'):
+            filename_lower = filename.lower()
+
+            if filename_lower.endswith('.csv'):
                 return FileProcessor._process_csv(decoded)
-            elif filename.endswith('.json'):
+            elif filename_lower.endswith('.json'):
                 return FileProcessor._process_json(decoded)
-            elif filename.endswith(('.xlsx', '.xls')):
+            elif filename_lower.endswith(('.xlsx', '.xls')):
                 return FileProcessor._process_excel(decoded)
             else:
                 return None

--- a/components/analytics/file_uploader.py
+++ b/components/analytics/file_uploader.py
@@ -168,12 +168,15 @@ class FileUploadController:
             content_type, content_string = upload_contents.split(',')
             decoded = base64.b64decode(content_string)
 
+            # Normalize file extension handling
+            filename_lower = filename.lower()
+
             # Parse based on file extension
-            if filename.endswith('.csv'):
+            if filename_lower.endswith('.csv'):
                 return self._parse_csv(decoded)
-            elif filename.endswith(('.xlsx', '.xls')):
+            elif filename_lower.endswith(('.xlsx', '.xls')):
                 return self._parse_excel(decoded)
-            elif filename.endswith('.json'):
+            elif filename_lower.endswith('.json'):
                 return self._parse_json(decoded)
             else:
                 raise ValueError(f"Unsupported file type: {filename}")

--- a/utils/file_validator.py
+++ b/utils/file_validator.py
@@ -54,7 +54,9 @@ def safe_decode_file(contents: str) -> Optional[bytes]:
 def process_dataframe(decoded: bytes, filename: str) -> Tuple[Optional[pd.DataFrame], Optional[str]]:
     """Process decoded bytes into DataFrame"""
     try:
-        if filename.endswith('.csv'):
+        filename_lower = filename.lower()
+
+        if filename_lower.endswith('.csv'):
             # Try multiple encodings
             for encoding in ['utf-8', 'latin-1', 'cp1252']:
                 try:
@@ -64,7 +66,7 @@ def process_dataframe(decoded: bytes, filename: str) -> Tuple[Optional[pd.DataFr
                     continue
             return None, "Could not decode CSV with any standard encoding"
 
-        elif filename.endswith('.json'):
+        elif filename_lower.endswith('.json'):
             import json
             json_data = json.loads(decoded.decode('utf-8'))
             if isinstance(json_data, list):
@@ -73,7 +75,7 @@ def process_dataframe(decoded: bytes, filename: str) -> Tuple[Optional[pd.DataFr
                 df = pd.DataFrame([json_data])
             return df, None
 
-        elif filename.endswith(('.xlsx', '.xls')):
+        elif filename_lower.endswith(('.xlsx', '.xls')):
             df = pd.read_excel(io.BytesIO(decoded))
             return df, None
 


### PR DESCRIPTION
## Summary
- normalize file extension handling in FileUploadController
- do the same in file_processing helper and file_validator utility

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_685a37caf7d4832082c5a465fa41eae2