### PR TITLE
Fix Pylance warnings

### DIFF
--- a/components/door_mapping_modal.py
+++ b/components/door_mapping_modal.py
@@ -2,11 +2,12 @@
 Door Mapping Modal Component for Device Attribute Assignment
 Integrates with Yōsai Intel Dashboard modular architecture
 """
-from dash import html, dcc, Input, Output, State
-from dash import callback_context
+from dash import html, dcc
+from dash.dependencies import Input, Output, State
+from dash._callback_context import callback_context
 import dash
 import dash_bootstrap_components as dbc
-from typing import Any, List, Dict, Optional
+from typing import Any, List, Dict, Optional, Union
 import logging
 import json
 
@@ -85,7 +86,7 @@ def create_door_mapping_modal() -> html.Div:
         return html.Div(f"Error creating door mapping modal: {str(e)}")
 
 
-def create_device_mapping_table(devices_data) -> html.Table:
+def create_device_mapping_table(devices_data) -> Union[html.Div, html.Table]:
     """Create the device mapping table.
 
     The input may be a list of dictionaries or a list of simple strings

--- a/core/plugins/protocols.py
+++ b/core/plugins/protocols.py
@@ -34,7 +34,7 @@ class PluginMetadata:
     description: str
     author: str
     priority: PluginPriority = PluginPriority.NORMAL
-    dependencies: List[str] = None
+    dependencies: Optional[List[str]] = None
     config_section: Optional[str] = None
     enabled_by_default: bool = True
     min_yosai_version: Optional[str] = None


### PR DESCRIPTION
## Summary
- address Pylance import warnings in `door_mapping_modal`
- correct optional type in plugin protocols

## Testing
- `flake8 components/door_mapping_modal.py core/plugins/protocols.py` *(fails: command not found)*
- `mypy components/door_mapping_modal.py core/plugins/protocols.py` *(fails: found 97 errors)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_685a61811168832090b40a08c19f6cd2