### PR TITLE
Use dedicated file upload layout

### DIFF
--- a/core/app_factory.py
+++ b/core/app_factory.py
@@ -207,62 +207,8 @@ def create_dashboard_page():
 def create_file_upload_page():
     """Create file upload page"""
     try:
-        return dbc.Container([
-            dbc.Row([
-                dbc.Col([
-                    html.H1("📂 File Upload & Processing", className="text-center mb-4"),
-                    html.P("Upload CSV, JSON, and Excel files for security analytics processing",
-                           className="text-center text-muted mb-4"),
-                ])
-            ]),
-
-            # Upload area
-            dbc.Row([
-                dbc.Col([
-                    dbc.Card([
-                        dbc.CardHeader("📤 Upload Files"),
-                        dbc.CardBody([
-                            dcc.Upload(
-                                id='upload-data',
-                                children=html.Div([
-                                    html.I(className="fas fa-cloud-upload-alt fa-3x mb-3"),
-                                    html.H4("Drag and Drop or Click to Upload"),
-                                    html.P("Supports CSV, JSON, Excel files")
-                                ], className="text-center p-4"),
-                                style={
-                                    'width': '100%',
-                                    'height': '200px',
-                                    'lineHeight': '200px',
-                                    'borderWidth': '2px',
-                                    'borderStyle': 'dashed',
-                                    'borderRadius': '10px',
-                                    'borderColor': '#ccc',
-                                    'textAlign': 'center',
-                                    'margin': '10px'
-                                },
-                                multiple=True
-                            ),
-                            html.Div(id='upload-output'),
-                            html.Div(id='upload-status-message', className="mt-3")
-                        ])
-                    ])
-                ])
-            ]),
-
-            # AI Column Mapping
-            dbc.Row([
-                dbc.Col([
-                    dbc.Card([
-                        dbc.CardHeader("🤖 AI Column Mapping"),
-                        dbc.CardBody([
-                            html.P("AI-powered column detection will appear here after file upload."),
-                            html.Div(id='column-mapping-area')
-                        ])
-                    ])
-                ], className="mt-4")
-            ])
-        ], fluid=True)
-
+        from pages import file_upload
+        return file_upload.layout()
     except Exception as e:
         logger.error(f"Error creating file upload page: {e}")
         return create_error_page("File upload page error")
@@ -378,19 +324,13 @@ def register_dashboard_callbacks(app):
 
 
 def register_file_upload_callbacks(app):
-    """Register file upload callbacks"""
+    """Ensure file upload callbacks are registered"""
     try:
-        @app.callback(
-            Output('upload-output', 'children'),
-            Input('upload-data', 'contents'),
-            prevent_initial_call=True
-        )
-        def update_output(contents):
-            if contents is not None:
-                return dbc.Alert("✅ File uploaded successfully!", color="success")
-            return ""
+        # Importing registers callbacks via @callback decorators
+        from components.analytics import file_uploader  # noqa: F401
+        logger.info("File upload callbacks registered")
     except Exception as e:
-        logger.error(f"Error registering upload callbacks: {e}")
+        logger.error(f"Error importing file upload callbacks: {e}")
 
 
 def register_analytics_callbacks(app):


### PR DESCRIPTION
## Summary
- import file upload module at the top of the app factory
- return the page layout directly from `pages.file_upload`
- delay file upload module import until the page is requested

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*


------
https://chatgpt.com/codex/tasks/task_e_685a647c60088320b9676271c932391e