### PR TITLE
Fix error path for file upload

### DIFF
--- a/components/analytics/file_uploader.py
+++ b/components/analytics/file_uploader.py
@@ -753,7 +753,22 @@ def _handle_file_upload(upload_contents, upload_filename):
 
     if not result['success']:
         error_msg = html.Div(result['error'], className="text-red-600")
-        return [{"display": "none"}] + [error_msg] + [""]*11
+        return [
+            {"display": "none"},
+            error_msg,
+            "",
+            [],
+            [],
+            [],
+            [],
+            None,
+            None,
+            None,
+            None,
+            {},
+            {},
+            {"display": "none"},
+        ]
 
     columns = result['columns']
     column_options = [{"label": col, "value": col} for col in columns]


### PR DESCRIPTION
## Summary
- ensure the failed upload return matches callback outputs

## Testing
- `flake8`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_685a6ee136208320a78c63f5e650caa6