### PR TITLE
Fix Dash imports

### DIFF
--- a/pages/deep_analytics.py
+++ b/pages/deep_analytics.py
@@ -12,15 +12,14 @@ def safe_text(text):
         return ""
     return str(text)
 
-# Safe imports with fallbacks
-try:
-    from dash import html, dcc, callback
-    from dash.dependencies import Input, Output, State
-    import dash_bootstrap_components as dbc
-    DASH_AVAILABLE = True
-except ImportError:
-    DASH_AVAILABLE = False
-    html = dcc = dbc = None
+# Dash components are required for this page
+from dash import html, dcc
+from dash._callback import callback
+from dash.dependencies import Input, Output, State
+import dash_bootstrap_components as dbc
+
+# Dash is expected to be installed when this module is used
+DASH_AVAILABLE = True
 
 try:
     from components.analytics import (


### PR DESCRIPTION
## Summary
- fix dash imports in `pages/deep_analytics.py` to follow Pylance suggestions

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_685a8a0b969083209137b32d01650bc4