### PR TITLE
Log AI mapping after column verification

### DIFF
--- a/components/analytics/file_uploader.py
+++ b/components/analytics/file_uploader.py
@@ -895,6 +895,12 @@ def _handle_mapping_verification(timestamp_col, device_col, user_col, event_col,
         mapping['event_type'] = event_col
 
     verification_result = upload_controller.verify_column_mapping(mapping, processed_store)
+    if verification_result.get('success'):
+        ai_mapping = {}
+        if processed_store:
+            ai_mapping = processed_store.get('ai_suggestions', {})
+        logger.info(f"AI column mapping suggestions: {ai_mapping}")
+        logger.info(f"Confirmed column mapping: {mapping}")
 
     if not verification_result['success']:
         error_msg = html.Div(verification_result['error'], className="text-red-600")


### PR DESCRIPTION
## Summary
- log AI column mapping suggestions and confirmed mapping when column mapping verification succeeds

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_685a9d39f7b88320b3fdf26e7a3f4293