### PR TITLE
Fix init modules

### DIFF
--- a/config/__init__.py
+++ b/config/__init__.py
@@ -1,20 +1,46 @@
-"""Simplified configuration package"""
+#!/usr/bin/env python3
+"""
+Simplified configuration package - Fixed imports
+"""
 
+# Import the main configuration system
 from .config import (
-    Config, AppConfig, DatabaseConfig, SecurityConfig,
-    ConfigManager, get_config, reload_config,
-    get_app_config, get_database_config, get_security_config,
+    Config,
+    AppConfig,
+    DatabaseConfig,
+    SecurityConfig,
+    ConfigManager,
+    get_config,
+    reload_config,
+    get_app_config,
+    get_database_config,
+    get_security_config
 )
 
-from .database_manager import (
-    DatabaseManager, MockConnection, DatabaseConfig as DBConfig,
-    SQLiteConnection, DatabaseConnection
-)
+# Try to import database manager safely
+try:
+    from .database_manager import DatabaseManager, DatabaseConnection, MockConnection
+    DATABASE_MANAGER_AVAILABLE = True
+except ImportError as e:
+    print(f"Warning: Database manager not available: {e}")
+    DatabaseManager = None
+    DatabaseConnection = None 
+    MockConnection = None
+    DATABASE_MANAGER_AVAILABLE = False
 
 __all__ = [
-    'Config', 'AppConfig', 'DatabaseConfig', 'SecurityConfig',
-    'ConfigManager', 'get_config', 'reload_config',
-    'get_app_config', 'get_database_config', 'get_security_config',
-    'DatabaseManager', 'MockConnection', 'DBConfig',
-    'SQLiteConnection', 'DatabaseConnection'
+    'Config',
+    'AppConfig',
+    'DatabaseConfig',
+    'SecurityConfig',
+    'ConfigManager',
+    'get_config',
+    'reload_config',
+    'get_app_config',
+    'get_database_config',
+    'get_security_config',
+    'DatabaseManager',
+    'DatabaseConnection',
+    'MockConnection',
+    'DATABASE_MANAGER_AVAILABLE'
 ]

--- a/core/__init__.py
+++ b/core/__init__.py
@@ -1,5 +1,6 @@
+#!/usr/bin/env python3
 """
-Core package initialization
+Core package initialization - Fixed for streamlined architecture
 """
 import logging
 
@@ -9,7 +10,7 @@ logging.basicConfig(
     format='%(asctime)s - %(name)s - %(levelname)s - %(message)s'
 )
 
-# Import the main app factory function
-from .app_factory import create_app, create_application
+# Import the main app factory function (only what exists)
+from .app_factory import create_app
 
-__all__ = ['create_app', 'create_application']
+__all__ = ['create_app']


### PR DESCRIPTION
## Summary
- simplify `core/__init__` to only expose `create_app`
- clean up `config/__init__` imports and make database manager optional

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_685b3be1ec308320ba16f37f3e1cdab5