### PR TITLE
Fix DataFrame empty checks in model factory

### DIFF
--- a/models/base.py
+++ b/models/base.py
@@ -216,6 +216,9 @@ class ModelFactory:
         models = {}
 
         try:
+            if df is None or df.empty:
+                logger.warning("Empty DataFrame provided to ModelFactory")
+                return {}
             # Create access model
             access_model = ModelFactory.create_access_model(df)
             if access_model.load_from_dataframe(df):


### PR DESCRIPTION
## Summary
- guard against empty pandas DataFrame when creating models

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_685b541635c4832084363e2bdcf9603b