### PR TITLE
Fix analytics functions and callback

### DIFF
--- a/pages/deep_analytics.py
+++ b/pages/deep_analytics.py
@@ -255,7 +255,7 @@ def generate_analytics_display(
     data_source: str,
     analysis_type: str,
 ):
-    """Generate and display complete analytics with service integration - FIXED VERSION"""
+    """Generate and display complete analytics with service integration - SIMPLIFIED VERSION"""
 
     if not n_clicks:
         return html.Div(), {}
@@ -269,14 +269,11 @@ def generate_analytics_display(
         analytics_results = analytics_service.get_analytics_by_source(data_source)
 
         if not analytics_results:
-            return (
-                create_info_alert(
-                    f"No data available from source: {data_source}. "
-                    "Try using sample data or upload files first.",
-                    "No Data Available",
-                ),
-                {},
-            )
+            return create_info_alert(
+                f"No data available from source: {data_source}. "
+                "Try using sample data or upload files first.",
+                "No Data Available"
+            ), {}
 
         enhanced_results = _enhance_analytics_by_type(
             analytics_results, analysis_type
@@ -285,13 +282,12 @@ def generate_analytics_display(
             enhanced_results, analysis_type, data_source
         )
 
-        sanitized_results = sanitize_for_json_store(enhanced_results)
-
         logger.info(
             f"Generated analytics for {data_source} source with {enhanced_results.get('total_events', 0)} events"
         )
 
-        return display_components, sanitized_results
+        # Return display components and results (now JSON-safe from source)
+        return display_components, enhanced_results
 
     except Exception as e:
         logger.error(f"Error generating analytics: {e}")
@@ -309,12 +305,13 @@ def generate_analytics_display(
 
 
 def _enhance_analytics_by_type(base_analytics: Dict[str, Any], analysis_type: str) -> Dict[str, Any]:
-    """Enhance analytics based on analysis type with complete integration"""
+    """Enhance analytics based on analysis type with complete integration - FIXED VERSION"""
     enhanced = base_analytics.copy()
 
     # Add analysis type metadata
     enhanced['analysis_type'] = analysis_type
-    enhanced['generated_at'] = pd.Timestamp.now().isoformat()
+    # CRITICAL FIX: Use datetime.now() instead of pd.Timestamp.now()
+    enhanced['generated_at'] = datetime.now().isoformat()
 
     if analysis_type == "security":
         enhanced['analysis_focus'] = "Security Patterns"

--- a/services/analytics_service.py
+++ b/services/analytics_service.py
@@ -100,14 +100,14 @@ class AnalyticsService:
         return self._generate_basic_analytics(sample_data)
 
     def _generate_basic_analytics(self, df: pd.DataFrame) -> Dict[str, Any]:
-        """Generate basic analytics from DataFrame"""
+        """Generate basic analytics from DataFrame - JSON safe version"""
         try:
             analytics = {
                 'status': 'success',
                 'total_rows': len(df),
                 'total_columns': len(df.columns),
                 'summary': {},
-                'timestamp': datetime.now().isoformat()
+                'timestamp': datetime.now().isoformat(),
             }
 
             # Basic statistics for each column
@@ -118,15 +118,16 @@ class AnalyticsService:
                         'mean': float(df[col].mean()),
                         'min': float(df[col].min()),
                         'max': float(df[col].max()),
-                        'null_count': int(df[col].isnull().sum())
+                        'null_count': int(df[col].isnull().sum()),
                     }
                 else:
                     value_counts = df[col].value_counts().head(10)
                     analytics['summary'][col] = {
                         'type': 'categorical',
                         'unique_values': int(df[col].nunique()),
-                        'top_values': value_counts.to_dict(),
-                        'null_count': int(df[col].isnull().sum())
+                        # Ensure keys/values are JSON serialisable
+                        'top_values': {str(k): int(v) for k, v in value_counts.items()},
+                        'null_count': int(df[col].isnull().sum()),
                     }
 
             return analytics


### PR DESCRIPTION
## Summary
- ensure generated analytics JSON keys are serializable
- handle datetime safely in analytics page
- simplify analytics generation callback

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_685b6fc94a7483208756a69b7b483a6f