### PR TITLE
Update analytics service key names

### DIFF
--- a/services/analytics_service.py
+++ b/services/analytics_service.py
@@ -145,7 +145,8 @@ class AnalyticsService:
         try:
             analytics = {
                 'status': 'success',
-                'total_rows': len(df),
+                'total_events': len(df),  # Changed from 'total_rows' to 'total_events'
+                'total_rows': len(df),    # Keep both for compatibility
                 'total_columns': len(df.columns),
                 'summary': {},
                 'timestamp': datetime.now().isoformat(),


### PR DESCRIPTION
## Summary
- update basic analytics dictionary keys in analytics service

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_685ba6689c508320b2d45bbabd63b4b0