### PR TITLE
Fix duplicate output error

### DIFF
--- a/pages/file_upload.py
+++ b/pages/file_upload.py
@@ -104,7 +104,7 @@ def layout():
 
 @callback(
     [
-        Output('upload-results', 'children'),
+        Output('upload-results', 'children', allow_duplicate=True),
         Output('file-preview', 'children'),
         Output('file-info-store', 'data'),
         Output('upload-nav', 'children'),


### PR DESCRIPTION
## Summary
- allow duplicates for `upload-results.children` output

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_685be90f65f48320b478d4442edb50db