### PR TITLE
Fix missing function and export list

### DIFF
--- a/pages/file_upload.py
+++ b/pages/file_upload.py
@@ -507,6 +507,13 @@ def toggle_verification_modal(verify_clicks, cancel_clicks, confirm_clicks, is_o
     prevent_initial_call=True,
 )
 
+def test_modal_open(n_clicks):
+    """Open modal when button clicked"""
+    if n_clicks:
+        return True
+    return False
+
+
 
 # Export functions for integration with other modules
 __all__ = [


### PR DESCRIPTION
## Summary
- add `test_modal_open` callback to open modal when the simple verify button is clicked
- keep exported functions list under `__all__`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_685bfc1f39288320b11d95966b5f3a3c