### PR TITLE
Fix simple device modal usage

### DIFF
--- a/pages/file_upload.py
+++ b/pages/file_upload.py
@@ -151,7 +151,12 @@ def layout():
                 is_open=False,
                 size="xl",
             ),
-            html.Div(id="simple-device-modal"),
+            create_simple_device_modal([
+                "main_entrance",
+                "office_door_201",
+                "server_room_3f",
+                "elevator_bank",
+            ]),
         ],
         fluid=True,
     )


### PR DESCRIPTION
## Summary
- use `create_simple_device_modal` in file upload layout
- simplify simple device mapping callbacks

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*
- `black . --check` *(fails: would reformat many files)*
- `flake8 .` *(fails: command not found)*
- `mypy .` *(fails: duplicate module error)*

------
https://chatgpt.com/codex/tasks/task_e_685cb40e12c08320b17862ecb834c148