### PR TITLE
Add smart AI device mapping features

### DIFF
--- a/components/simple_device_mapping.py
+++ b/components/simple_device_mapping.py
@@ -5,6 +5,108 @@ import dash
 import dash_bootstrap_components as dbc
 from typing import List
 
+# Global storage for AI device mappings
+_device_ai_mappings = {}
+
+
+def create_simple_device_modal_with_ai(devices: List[str]) -> dbc.Modal:
+    """Create simple device mapping modal with AI learning transfer"""
+    global _device_ai_mappings
+
+    if not devices:
+        devices = ["lobby_door", "office_201", "server_room", "elevator_1"]
+
+    # Create rows for each device
+    device_rows = []
+    for i, device in enumerate(devices):
+        ai_data = _device_ai_mappings.get(device, {})
+
+        default_floor = ai_data.get('floor_number')
+        default_security = ai_data.get('security_level', 5)
+        default_access = []
+        if ai_data.get('is_entry'):
+            default_access.append('entry')
+        if ai_data.get('is_exit'):
+            default_access.append('exit')
+
+        device_rows.append(
+            dbc.Row([
+                dbc.Col([
+                    html.Strong(device),
+                    html.Br() if ai_data else None,
+                    dbc.Badge("AI Suggested", color="info", className="small") if ai_data else None
+                ], width=4),
+                dbc.Col([
+                    dbc.Input(
+                        id={"type": "device-floor", "index": i},
+                        type="number",
+                        placeholder="Floor #",
+                        min=0,
+                        max=50,
+                        value=default_floor,
+                        size="sm",
+                    )
+                ], width=2),
+                dbc.Col([
+                    dbc.Checklist(
+                        id={"type": "device-access", "index": i},
+                        options=[
+                            {"label": "Entry", "value": "entry"},
+                            {"label": "Exit", "value": "exit"},
+                        ],
+                        value=default_access,
+                        inline=True,
+                    )
+                ], width=3),
+                dbc.Col([
+                    dbc.Input(
+                        id={"type": "device-security", "index": i},
+                        type="number",
+                        placeholder="0-10",
+                        min=0,
+                        max=10,
+                        value=default_security,
+                        size="sm",
+                    )
+                ], width=2),
+                dcc.Store(id={"type": "device-name", "index": i}, data=device),
+            ], className="mb-2")
+        )
+
+    modal_body = html.Div([
+        dbc.Alert([
+            "Manually assign floor numbers and security levels to devices. ",
+            html.Strong("AI suggestions have been pre-filled!") if _device_ai_mappings else "Fill in device details manually."
+        ], color="info" if _device_ai_mappings else "warning"),
+        dbc.Alert([
+            html.Strong(f"🤖 AI Transfer: "),
+            f"Loaded {len(_device_ai_mappings)} AI-learned device mappings as defaults"
+        ], color="light", className="small") if _device_ai_mappings else None,
+        dbc.Row([
+            dbc.Col(html.Strong("Device Name"), width=4),
+            dbc.Col(html.Strong("Floor"), width=2),
+            dbc.Col(html.Strong("Access"), width=3),
+            dbc.Col(html.Strong("Security (0-10)"), width=2),
+        ], className="mb-2"),
+        html.Hr(),
+        html.Div(device_rows),
+        html.Hr(),
+        dbc.Alert([
+            html.Strong("Security Levels: "),
+            "0-2: Public areas, 3-5: Office areas, 6-8: Restricted, 9-10: High security",
+        ], color="light", className="small"),
+    ])
+
+    return dbc.Modal([
+        dbc.ModalHeader("Device Mapping with AI Learning"),
+        dbc.ModalBody(modal_body),
+        dbc.ModalFooter([
+            dbc.Button("Cancel", id="device-modal-cancel", color="secondary"),
+            dbc.Button("Save", id="device-modal-save", color="primary"),
+        ]),
+    ], id="simple-device-modal", size="lg", is_open=False)
+
+
 
 def create_simple_device_modal(devices: List[str]) -> dbc.Modal:
     """Create simple device mapping modal"""


### PR DESCRIPTION
## Summary
- add `analyze_device_name_with_ai` for improved device name parsing
- generate device modal contents using smart AI analysis
- show success message and keep buttons when confirming devices
- store AI device mappings for reuse in manual mapping modal
- surface AI suggestions in manual mapping modal

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_685cc03a21b88320abcc0b10517cf8c5