### PR TITLE
Add hidden callbacks placeholders

### DIFF
--- a/pages/file_upload.py
+++ b/pages/file_upload.py
@@ -169,6 +169,11 @@ def layout():
             dbc.Row([dbc.Col([html.Div(id="file-preview")])]),
             # Navigation to analytics
             dbc.Row([dbc.Col([html.Div(id="upload-nav")])]),
+            # PLACEHOLDER BUTTONS - prevent callback reference errors
+            html.Div([
+                dbc.Button("", id="verify-columns-btn-simple", style={"display": "none"}),
+                dbc.Button("", id="classify-devices-btn", style={"display": "none"}),
+            ], style={"display": "none"}),
             # Store for uploaded data info
             dcc.Store(id="file-info-store", data={}),
             dcc.Store(id="current-file-info-store"),


### PR DESCRIPTION
## Summary
- include invisible buttons in file upload layout to satisfy callbacks referencing them

## Testing
- `pytest -q`
- `mypy .`
- `black . --check`
- `flake8 .`

------
https://chatgpt.com/codex/tasks/task_e_685cdcd7b40c83208c033fca411714ea