### PR TITLE
Fix upload routing

### DIFF
--- a/core/app_factory.py
+++ b/core/app_factory.py
@@ -137,7 +137,7 @@ def display_page(pathname):
     """Route pages based on URL"""
     if pathname == "/analytics":
         return _get_analytics_page()
-    elif pathname == "/upload":
+    elif pathname == "/upload" or pathname == "/file-upload":  # Handle both paths
         return _get_upload_page()
     elif pathname == "/":
         return _get_home_page()

--- a/pages/file_upload.py
+++ b/pages/file_upload.py
@@ -427,10 +427,13 @@ def highlight_upload_area(n_clicks):
 def restore_upload_on_page_load(pathname):
     """Restore upload state when returning to upload page"""
 
-    if pathname != "/upload":
+    # Fix: Check for the correct path that navbar uses
+    if pathname != "/file-upload":  # Changed from "/upload" to "/file-upload"
         return no_update, no_update, no_update, no_update
 
+    # Check if we have uploaded data in global store
     if not _uploaded_data_store:
+        print("🔄 No uploaded data to restore")
         return no_update, no_update, no_update, no_update
 
     print(f"🔄 Restoring upload state for {len(_uploaded_data_store)} files")


### PR DESCRIPTION
## Summary
- ensure restore callback checks `/file-upload`
- route both `/upload` and `/file-upload` to the upload page

## Testing
- `python test_modular_system.py` *(fails: No such file or directory)*
- `python tests/test_dashboard.py` *(fails: No such file or directory)*
- `pytest` *(fails: Missing dependency pandas)*
- `mypy .` *(fails: duplicate module error)*
- `black . --check` *(fails: would reformat many files)*
- `flake8 .` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685cf5c31538832097d6063671f36cc8