### PR TITLE
Fix special areas checklist

### DIFF
--- a/components/simple_device_mapping.py
+++ b/components/simple_device_mapping.py
@@ -81,12 +81,17 @@ def create_simple_device_modal_with_ai(devices: List[str]) -> dbc.Modal:
                         ],
                         width=2,
                     ),
+                    # ADD THIS NEW COLUMN:
                     dbc.Col(
                         [
                             dbc.Checklist(
                                 id={"type": "device-special", "index": i},
-                                options=special_areas_options,
-                                value=[],
+                                options=[
+                                    {"label": "Elevator", "value": "is_elevator"},
+                                    {"label": "Stairwell", "value": "is_stairwell"},
+                                    {"label": "Fire Exit", "value": "is_fire_escape"},
+                                ],  # HARDCODED instead of special_areas_options
+                                value=[],  # Default empty
                                 inline=True,
                             )
                         ],


### PR DESCRIPTION
## Summary
- fix special areas checklist options by hardcoding the values

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_685d310a806083208a0fb757353caaff