### PR TITLE
Fix import paths for Dash modules

### DIFF
--- a/components/device_verification.py
+++ b/components/device_verification.py
@@ -1,10 +1,12 @@
 """Device verification component - follows exact same pattern as column_verification.py"""
 
 import pandas as pd
-from dash import html, dcc, callback, Input, Output, State, ALL, MATCH
+from dash import html, dcc
+from dash._callback import callback
+from dash.dependencies import Input, Output, State, ALL, MATCH
 import dash
 import dash_bootstrap_components as dbc
-from typing import Dict, List, Any
+from typing import Dict, List, Any, Union
 import logging
 from datetime import datetime
 from components.simple_device_mapping import _device_ai_mappings, special_areas_options
@@ -14,7 +16,7 @@ logger = logging.getLogger(__name__)
 
 def create_device_verification_modal(
     device_mappings: Dict[str, Dict], session_id: str
-) -> dbc.Modal:
+) -> Union[dbc.Modal, html.Div]:
     """Create device verification modal - same pattern as column verification"""
 
     if not device_mappings:

--- a/ui_diagnostic.py
+++ b/ui_diagnostic.py
@@ -12,7 +12,9 @@ def test_imports():
     
     # Test Dash core
     try:
-        from dash import html, dcc, callback, Input, Output
+        from dash import html, dcc
+        from dash._callback import callback
+        from dash.dependencies import Input, Output
         imports_status['dash_core'] = True
         print("✅ Dash core components: OK")
     except ImportError as e:


### PR DESCRIPTION
## Summary
- fix dash imports per Pylance warnings
- allow early return in device verification modal to be `html.Div`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_685d344821948320952ed458656fbc7f