### PR TITLE
Add Stairwell and Fire Exit options

### DIFF
--- a/pages/file_upload.py
+++ b/pages/file_upload.py
@@ -840,15 +840,21 @@ def populate_device_modal_with_learning(is_open, file_info):
                                     id={"type": "device-special", "index": i},
                                     options=[
                                         {"label": "Elevator", "value": "is_elevator"},
-                                        {
-                                            "label": "Restricted",
-                                            "value": "is_restricted",
-                                        },
-                                    ],
+                                        {"label": "Restricted", "value": "is_restricted"},
+                                        {"label": "Stairwell", "value": "is_stairwell"},
+                                        {"label": "Fire Exit", "value": "is_fire_escape"},
+                                    ],  # ADDED Stairwell and Fire Exit
                                     value=[
                                         k
                                         for k, v in ai_attributes.items()
-                                        if k in ["is_elevator", "is_restricted"] and v
+                                        if k
+                                        in [
+                                            "is_elevator",
+                                            "is_restricted",
+                                            "is_stairwell",
+                                            "is_fire_escape",
+                                        ]
+                                        and v
                                     ],
                                     inline=False,
                                 )


### PR DESCRIPTION
## Summary
- expand special area options in `file_upload.py` for Stairwell and Fire Exit

## Testing
- `python test_modular_system.py` *(fails: file not found)*
- `python tests/test_dashboard.py` *(fails: file not found)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*
- `mypy .` *(fails: found 1 error)*
- `black . --check` *(fails: many files would be reformatted)*
- `flake8 .` *(fails: command not found)*


------
https://chatgpt.com/codex/tasks/task_e_685d3579aea883208cbaf7a1385ca64b