### PR TITLE
Fix AI device generator and tests

### DIFF
--- a/services/ai_device_generator.py
+++ b/services/ai_device_generator.py
@@ -25,69 +25,80 @@ class DeviceAttributes:
 
 class AIDeviceGenerator:
     """Consolidated AI device attribute generator."""
-
+    
     def __init__(self):
         self.logger = logging.getLogger(__name__)
-
-        # Floor extraction patterns
+        
+        # Floor extraction patterns (order matters - most specific first)
         self.floor_patterns = [
             (r'[Ll](\d+)', lambda m: int(m.group(1))),  # L1, l2
-            (r'[Ff]loor.*?(\d+)', lambda m: int(m.group(1))),  # floor_3
             (r'(\d+)[Ff]', lambda m: int(m.group(1))),  # 2F, 3f
-            (r'^(\d+)_', lambda m: int(m.group(1))),  # 1_door
-            (r'_(\d+)_', lambda m: int(m.group(1))),  # office_2_door
+            (r'[Ff]loor.*?(\d+)', lambda m: int(m.group(1))),  # floor_3
+            (r'^(\d+)_', lambda m: int(m.group(1))),  # 1_door (only at start)
+            # Room number pattern - extract floor from room numbers like 201, 301
+            (r'_(\d)(\d{2})_', lambda m: int(m.group(1))),  # _201_ -> floor 2
+            (r'_(\d)(\d{2})$', lambda m: int(m.group(1))),  # _201 -> floor 2
         ]
-
-        # Security level patterns (pattern -> level)
-        self.security_patterns = {
-            r'lobby|reception|public|entrance': 2,
-            r'office|desk|workspace|room_\d+': 4,
-            r'meeting|conference|boardroom': 5,
-            r'server|data|it|network': 8,
-            r'executive|ceo|president|admin': 7,
-            r'secure|restricted|vault|safe': 9,
-            r'emergency|fire|safety': 6,
-            r'elevator|lift': 3,
-            r'stair|stairs': 3
-        }
-
+        
+        # Security level patterns (pattern -> level) - order matters
+        self.security_patterns = [
+            (r'lobby|reception|public|entrance', 2),
+            (r'elevator|lift', 3),
+            (r'stair|stairs', 3),
+            (r'office|desk|workspace|room_\d+', 4),
+            (r'meeting|conference|boardroom', 5),
+            (r'emergency|fire|safety', 6),
+            (r'executive|ceo|president', 7),  # More specific before 'server'
+            (r'server|data|network', 8),  # Removed 'it' to avoid matching 'suite'
+            (r'secure|restricted|vault|safe', 9),
+        ]
+        
         # Access type patterns
         self.access_patterns = {
-            'entry': [r'entry|entrance|in|lobby|front'],
-            'exit': [r'exit|egress|out|emergency|back'],
+            'entry': [r'entry|entrance|lobby|front'],
+            'exit': [r'exit|egress|back'],
             'elevator': [r'elevator|lift|elev'],
             'stairwell': [r'stair|stairs|step'],
-            'fire_escape': [r'fire|emergency.*exit|escape']
+            'fire_escape': [r'fire.*escape|emergency.*exit']
         }
 
-    def generate_device_attributes(self, device_id: str,
-                                   usage_data: Optional[pd.DataFrame] = None) -> DeviceAttributes:
-        """Generate comprehensive device attributes using AI analysis."""
+    def generate_device_attributes(self, device_id: str, 
+                                 usage_data: Optional[pd.DataFrame] = None) -> DeviceAttributes:
+        """
+        Generate comprehensive device attributes using AI analysis.
+        
+        Args:
+            device_id: Device identifier to analyze
+            usage_data: Optional usage patterns for enhanced analysis
+            
+        Returns:
+            DeviceAttributes with AI-generated properties
+        """
         device_lower = device_id.lower()
-        reasoning_parts: List[str] = []
-
+        reasoning_parts = []
+        
         # Extract floor number
         floor_num = self._extract_floor(device_id, reasoning_parts)
-
+        
         # Calculate security level
         security_level = self._calculate_security_level(device_lower, reasoning_parts)
-
+        
         # Determine access types
         access_flags = self._determine_access_types(device_lower, reasoning_parts)
-
+        
         # Generate readable name
         device_name = self._generate_device_name(device_id, reasoning_parts)
-
+        
         # Calculate confidence
         confidence = self._calculate_confidence(reasoning_parts)
-
+        
         return DeviceAttributes(
             device_id=device_id,
             device_name=device_name,
             floor_number=floor_num,
             security_level=security_level,
             is_entry=access_flags['entry'],
-            is_exit=access_flags['exit'],
+            is_exit=access_flags['exit'] or access_flags['fire_escape'],  # Fire escapes are exits
             is_elevator=access_flags['elevator'],
             is_stairwell=access_flags['stairwell'],
             is_fire_escape=access_flags['fire_escape'],
@@ -102,47 +113,71 @@ class AIDeviceGenerator:
             if match:
                 try:
                     floor = extractor(match)
-                    reasoning.append(f"Floor {floor} detected from pattern")
-                    return max(1, floor)
+                    # Reasonable floor validation
+                    if 1 <= floor <= 99:
+                        reasoning.append(f"Floor {floor} detected from pattern")
+                        return floor
                 except (ValueError, IndexError):
                     continue
+        
         reasoning.append("Floor 1 (default - no pattern match)")
         return 1
 
     def _calculate_security_level(self, device_lower: str, reasoning: List[str]) -> int:
         """Calculate security level based on naming patterns."""
-        for pattern, level in self.security_patterns.items():
+        for pattern, level in self.security_patterns:
             if re.search(pattern, device_lower):
                 reasoning.append(f"Security level {level} from device type")
                 return level
+        
         reasoning.append("Security level 5 (default office)")
         return 5
 
     def _determine_access_types(self, device_lower: str, reasoning: List[str]) -> Dict[str, bool]:
         """Determine access type boolean flags."""
         flags = {access_type: False for access_type in self.access_patterns.keys()}
+        
         for access_type, patterns in self.access_patterns.items():
             for pattern in patterns:
                 if re.search(pattern, device_lower):
                     flags[access_type] = True
                     reasoning.append(f"Detected {access_type} access")
                     break
+        
         return flags
 
     def _generate_device_name(self, device_id: str, reasoning: List[str]) -> str:
         """Generate human-readable device name."""
+        # Replace underscores and hyphens with spaces
         name = re.sub(r'[_-]', ' ', device_id)
-        name = re.sub(r'([a-zA-Z])(\d)', r'\1 \2', name)
+        
+        # Add spaces before numbers, but preserve existing letter-number combinations
+        # Don't add space if there's already a space or if it's like "L1"
+        name = re.sub(r'([a-zA-Z])([0-9])', lambda m: 
+                     f"{m.group(1)} {m.group(2)}" if len(m.group(1)) > 1 else m.group(0), name)
+        
+        # Capitalize words
         name = ' '.join(word.capitalize() for word in name.split())
-        reasoning.append("Generated readable name")
+        
+        reasoning.append(f"Generated readable name")
         return name
 
     def _calculate_confidence(self, reasoning: List[str]) -> float:
         """Calculate AI confidence based on successful pattern matches."""
         base_confidence = 0.5
-        pattern_matches = len([r for r in reasoning if 'detected' in r or 'pattern' in r])
-        confidence_boost = min(pattern_matches * 0.1, 0.4)
-        return min(base_confidence + confidence_boost, 0.95)
+        
+        # Count successful detections (not defaults)
+        successful_detections = len([r for r in reasoning if 'detected' in r or 'pattern' in r])
+        default_detections = len([r for r in reasoning if 'default' in r])
+        
+        # Boost for successful pattern matches
+        confidence_boost = successful_detections * 0.15
+        
+        # Reduce for defaults
+        confidence_penalty = default_detections * 0.05
+        
+        final_confidence = base_confidence + confidence_boost - confidence_penalty
+        return min(max(final_confidence, 0.3), 0.95)  # Clamp between 0.3 and 0.95
 
 
 def create_ai_device_generator() -> AIDeviceGenerator:

--- a/tests/test_ai_device_generator.py
+++ b/tests/test_ai_device_generator.py
@@ -2,70 +2,92 @@
 Test suite for AI device generator module.
 """
 import pytest
-from services.ai_device_generator import AIDeviceGenerator
+from services.ai_device_generator import AIDeviceGenerator, DeviceAttributes
 
 class TestAIDeviceGenerator:
-
+    
     def setup_method(self):
+        """Setup test instance."""
         self.generator = AIDeviceGenerator()
-
+    
     def test_floor_extraction_patterns(self):
+        """Test floor number extraction from various patterns."""
         test_cases = [
             ("lobby_L1_door", 1),
             ("office_3F_main", 3),
-            ("floor_2_entrance", 2),
+            ("floor_2_entrance", 2), 
             ("5_server_room", 5),
-            ("basement_door", 1),
-            ("office_201_door", 2),
+            ("basement_door", 1),  # default
+            ("office_201_door", 2),  # from room number pattern
         ]
-        for device_id, expected in test_cases:
+        
+        for device_id, expected_floor in test_cases:
             attrs = self.generator.generate_device_attributes(device_id)
-            assert attrs.floor_number == expected
-
+            assert attrs.floor_number == expected_floor, f"Failed for {device_id}: got {attrs.floor_number}, expected {expected_floor}"
+    
     def test_security_level_detection(self):
+        """Test security level assignment."""
         test_cases = [
-            ("lobby_entrance", 2),
-            ("office_201", 4),
-            ("server_room_door", 8),
-            ("executive_suite", 7),
-            ("elevator_1", 3),
-            ("vault_door", 9),
+            ("lobby_entrance", 2),      # public
+            ("office_201", 4),          # office
+            ("server_room_door", 8),    # secure
+            ("executive_suite", 7),     # executive (fixed pattern)
+            ("elevator_1", 3),          # elevator
+            ("vault_door", 9),          # vault
         ]
-        for device_id, expected in test_cases:
+        
+        for device_id, expected_security in test_cases:
             attrs = self.generator.generate_device_attributes(device_id)
-            assert attrs.security_level == expected
-
+            assert attrs.security_level == expected_security, f"Failed for {device_id}: got {attrs.security_level}, expected {expected_security}"
+    
     def test_access_type_detection(self):
+        """Test access type flag detection."""
         test_cases = [
-            ("main_entrance", True, False, False),
-            ("emergency_exit", False, True, False),
-            ("elevator_1", False, False, True),
-            ("fire_escape", False, True, False),
+            ("main_entrance", True, False, False),  # entry, not exit, not elevator
+            ("emergency_exit", False, True, False),  # exit, not entry
+            ("elevator_1", False, False, True),      # elevator
+            ("fire_escape", False, True, False),     # fire escape (counts as exit)
         ]
+        
         for device_id, expect_entry, expect_exit, expect_elevator in test_cases:
             attrs = self.generator.generate_device_attributes(device_id)
-            assert attrs.is_entry == expect_entry
-            assert attrs.is_exit == expect_exit
-            assert attrs.is_elevator == expect_elevator
-
+            assert attrs.is_entry == expect_entry, f"Entry failed for {device_id}: got {attrs.is_entry}, expected {expect_entry}"
+            assert attrs.is_exit == expect_exit, f"Exit failed for {device_id}: got {attrs.is_exit}, expected {expect_exit}" 
+            assert attrs.is_elevator == expect_elevator, f"Elevator failed for {device_id}: got {attrs.is_elevator}, expected {expect_elevator}"
+    
     def test_device_name_generation(self):
+        """Test readable name generation."""
         test_cases = [
-            ("lobby_L1_door", "Lobby L1 Door"),
-            ("office_201", "Office 201"),
-            ("server-room_3F", "Server Room 3 F"),
+            ("lobby_L1_door", "Lobby L1 Door"),  # Preserve L1
+            ("office_201", "Office 201"),        # Keep room numbers together
+            ("server-room_3F", "Server Room 3F"), # Handle both separators
         ]
+        
         for device_id, expected_name in test_cases:
             attrs = self.generator.generate_device_attributes(device_id)
-            assert attrs.device_name == expected_name
-
+            assert attrs.device_name == expected_name, f"Name failed for {device_id}: got '{attrs.device_name}', expected '{expected_name}'"
+    
     def test_confidence_calculation(self):
+        """Test confidence scoring."""
+        # Device with clear patterns should have higher confidence
         clear_attrs = self.generator.generate_device_attributes("office_3F_entrance")
         unclear_attrs = self.generator.generate_device_attributes("device_123")
-        assert clear_attrs.confidence > unclear_attrs.confidence
-        assert 0.5 <= clear_attrs.confidence <= 0.95
-        assert 0.5 <= unclear_attrs.confidence <= 0.95
-
+        
+        assert clear_attrs.confidence > unclear_attrs.confidence, f"Clear confidence {clear_attrs.confidence} should be > unclear confidence {unclear_attrs.confidence}"
+        assert 0.3 <= clear_attrs.confidence <= 0.95
+        assert 0.3 <= unclear_attrs.confidence <= 0.95
+    
     def test_ai_reasoning_output(self):
+        """Test that AI reasoning is populated."""
         attrs = self.generator.generate_device_attributes("office_2F_door")
-        assert attrs.ai_reasoning
+        
+        assert attrs.ai_reasoning is not None
+        assert len(attrs.ai_reasoning) > 0
         assert "Floor" in attrs.ai_reasoning or "Security" in attrs.ai_reasoning
+    
+    def test_fire_escape_is_exit(self):
+        """Test that fire escapes are marked as exits."""
+        attrs = self.generator.generate_device_attributes("fire_escape_door")
+        
+        assert attrs.is_fire_escape == True
+        assert attrs.is_exit == True  # Fire escapes should also be exits


### PR DESCRIPTION
## Summary
- implement revised logic in `AIDeviceGenerator`
- update tests for updated generator behavior

## Testing
- `pytest tests/test_ai_device_generator.py::TestAIDeviceGenerator::test_confidence_calculation -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_685d7558110483209cd8ed042ea9443e