### PR TITLE
Remove debug output and refine device generator

### DIFF
--- a/pages/file_upload.py
+++ b/pages/file_upload.py
@@ -743,7 +743,7 @@ def apply_ai_suggestions(n_clicks, file_info):
     prevent_initial_call=True,
 )
 def populate_device_modal_with_learning(is_open, file_info):
-    """Fixed device modal population - gets ALL devices WITH DEBUG"""
+    """Fixed device modal population - gets ALL devices"""
     if not is_open:
         return "Modal closed"
 
@@ -767,32 +767,6 @@ def populate_device_modal_with_learning(is_open, file_info):
                     all_devices.update(str(val) for val in unique_vals)
                     print(f"   Found {len(unique_vals)} devices in column '{col}'")
 
-                    # ADD THIS DEBUG SECTION
-                    print(f"🔍 DEBUG - First 10 device names from '{col}':")
-                    sample_devices = unique_vals[:10]
-                    for i, device in enumerate(sample_devices, 1):
-                        print(f"   {i:2d}. {device}")
-
-                    # TEST AI on sample devices
-                    print(f"🤖 DEBUG - Testing AI on sample devices:")
-                    try:
-                        from services.ai_device_generator import AIDeviceGenerator
-                        ai_gen = AIDeviceGenerator()
-
-                        for device in sample_devices[:5]:  # Test first 5
-                            try:
-                                result = ai_gen.generate_device_attributes(str(device))
-                                print(
-                                    f"   🚪 '{device}' → Name: '{result.device_name}', Floor: {result.floor_number}, Security: {result.security_level}, Confidence: {result.confidence:.1%}"
-                                )
-                                print(
-                                    f"      Access: Entry={result.is_entry}, Exit={result.is_exit}, Elevator={result.is_elevator}"
-                                )
-                                print(f"      Reasoning: {result.ai_reasoning}")
-                            except Exception as e:
-                                print(f"   ❌ AI error on '{device}': {e}")
-                    except Exception as e:
-                        print(f"🤖 DEBUG - AI import error: {e}")
 
         actual_devices = sorted(list(all_devices))
         print(f"🎯 Total unique devices found: {len(actual_devices)}")
@@ -851,7 +825,7 @@ def populate_device_modal_with_learning(is_open, file_info):
                 dbc.Alert(
                     [
                         html.Strong("🤖 AI Analysis: "),
-                        f"Analyzed {len(actual_devices)} devices. Check console for detailed AI debug info.",
+                        f"Analyzed {len(actual_devices)} devices with enhanced patterns.",
                     ],
                     color="info",
                     className="mb-3",

--- a/services/ai_device_generator.py
+++ b/services/ai_device_generator.py
@@ -32,18 +32,18 @@ class AIDeviceGenerator:
         # Floor extraction patterns - FIXED for F01A, F02B format
         self.floor_patterns = [
             # Your specific format: F01A, F02B, F03C, etc. - FIXED REGEX
-            (r'[Ff]0*(\d+)[A-Z]', lambda m: int(m.group(1))),
-            (r'[Ff](\d{2,3})[A-Z]', lambda m: int(m.group(1)[:1]) if len(m.group(1)) >= 2 else int(m.group(1))),
-
+            (r'[Ff]0*(\d+)[A-Z]', lambda m: int(m.group(1))),  # F01A → 1, F02B → 2
+            (r'[Ff](\d{2,3})[A-Z]', lambda m: int(m.group(1)[:1]) if len(m.group(1)) >= 2 else int(m.group(1))),  # F10A → 1 (first digit)
+            
             # Alternative patterns for your format
-            (r'^[Ff]0*(\d+)', lambda m: int(m.group(1))),
-            (r'[Ff]0*(\d+)', lambda m: int(m.group(1))),
-
+            (r'^[Ff]0*(\d+)', lambda m: int(m.group(1))),      # F01, F02, F03 at start
+            (r'[Ff]0*(\d+)', lambda m: int(m.group(1))),       # F01, F02, F03 anywhere
+            
             # Standard patterns
-            (r'[Ll](\d+)', lambda m: int(m.group(1))),
-            (r'(\d+)[Ff]', lambda m: int(m.group(1))),
-            (r'[Ff]loor.*?(\d+)', lambda m: int(m.group(1))),
-            (r'^(\d+)_', lambda m: int(m.group(1))),
+            (r'[Ll](\d+)', lambda m: int(m.group(1))),         # L1, l2
+            (r'(\d+)[Ff]', lambda m: int(m.group(1))),         # 2F, 3f  
+            (r'[Ff]loor.*?(\d+)', lambda m: int(m.group(1))),  # floor_3
+            (r'^(\d+)_', lambda m: int(m.group(1))),           # 1_door
         ]
         
         # Security level patterns - UPDATED for your device types
@@ -134,30 +134,18 @@ class AIDeviceGenerator:
 
     def _extract_floor(self, device_id: str, reasoning: List[str]) -> int:
         """Extract floor number using enhanced pattern matching."""
-        # DEBUG: Print what we're trying to match
-        print(f"🔍 DEBUG Floor extraction for: '{device_id}'")
-
-        for i, (pattern, extractor) in enumerate(self.floor_patterns):
-            print(f"   Pattern {i+1}: {pattern}")
+        for pattern, extractor in self.floor_patterns:
             match = re.search(pattern, device_id)
             if match:
-                print(f"   ✅ MATCHED! Groups: {match.groups()}")
                 try:
                     floor = extractor(match)
                     if 1 <= floor <= 99:  # Reasonable floor range
                         reasoning.append(f"Floor {floor} extracted from pattern '{pattern}'")
-                        print(f"   🎯 Extracted floor: {floor}")
                         return floor
-                    else:
-                        print(f"   ❌ Floor {floor} out of range")
-                except (ValueError, IndexError) as e:
-                    print(f"   ❌ Extraction error: {e}")
+                except (ValueError, IndexError):
                     continue
-            else:
-                print(f"   ❌ No match")
-
+        
         reasoning.append("Floor 1 (default - no pattern match)")
-        print(f"   🔄 Using default floor 1")
         return 1
 
     def _calculate_security_level(self, device_lower: str, reasoning: List[str]) -> int:


### PR DESCRIPTION
## Summary
- clean up `services/ai_device_generator.py` removing debug prints
- strip debugging section from `populate_device_modal_with_learning`
- tweak modal message for AI analysis

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_685d8301022c8320a77872433557b810