### PR TITLE
Update AI device generator patterns

### DIFF
--- a/services/ai_device_generator.py
+++ b/services/ai_device_generator.py
@@ -31,9 +31,13 @@ class AIDeviceGenerator:
         
         # Floor extraction patterns - UPDATED for F01A, F02B format
         self.floor_patterns = [
-            # Your specific format: F01A, F02B, F03C, etc.
-            (r'[Ff]0*(\d+)[A-Z]', lambda m: int(m.group(1))),  # F01A → 1, F02B → 2, F10C → 10
-            (r'[Ff](\d+)[A-Z]', lambda m: int(m.group(1))),    # F1A → 1, F2B → 2 (no leading zero)
+            # Your specific format: F01A, F02B, F03C, etc. - FIXED REGEX
+            (r'[Ff]0*(\d+)[A-Z]', lambda m: int(m.group(1))),  # F01A → 1, F02B → 2
+            (r'[Ff](\d{2,3})[A-Z]', lambda m: int(m.group(1)[:1]) if len(m.group(1)) >= 2 else int(m.group(1))),  # F10A → 1 (first digit)
+            
+            # Alternative patterns for your format
+            (r'^[Ff]0*(\d+)', lambda m: int(m.group(1))),      # F01, F02, F03 at start
+            (r'[Ff]0*(\d+)', lambda m: int(m.group(1))),       # F01, F02, F03 anywhere
             
             # Standard patterns
             (r'[Ll](\d+)', lambda m: int(m.group(1))),         # L1, l2
@@ -136,7 +140,7 @@ class AIDeviceGenerator:
                 try:
                     floor = extractor(match)
                     if 1 <= floor <= 99:  # Reasonable floor range
-                        reasoning.append(f"Floor {floor} extracted from '{device_id}' pattern")
+                        reasoning.append(f"Floor {floor} extracted from pattern '{pattern}'")
                         return floor
                 except (ValueError, IndexError):
                     continue


### PR DESCRIPTION
## Summary
- replace `AIDeviceGenerator` implementation with enhanced version supporting codes like `F01A`

## Testing
- `PYTHONPATH=$PWD pytest -q tests/test_ai_device_generator.py` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_685dd42c97bc8320b08b1737c9e4156e