### PR TITLE
Fix device modal confirm saving

### DIFF
--- a/pages/file_upload.py
+++ b/pages/file_upload.py
@@ -202,6 +202,8 @@ def layout():
                 is_open=False,
                 size="xl",
             ),
+            # Area to show learning save status
+            html.Div(id="device-learning-status", className="mt-3"),
         ],
         fluid=True,
     )
@@ -414,6 +416,8 @@ def highlight_upload_area(n_clicks):
         "cursor": "pointer",
         "backgroundColor": "#f8f9fa",
     }
+
+
 @callback(
     [
         Output("upload-results", "children"),
@@ -445,17 +449,27 @@ def highlight_upload_area(n_clicks):
     prevent_initial_call=False,
 )
 def consolidated_upload_callback(
-    contents_list, verify_clicks, classify_clicks, confirm_clicks,
-    cancel_col_clicks, cancel_dev_clicks, confirm_dev_clicks, pathname,
-    filenames_list, dropdown_values, dropdown_ids, file_info,
-    col_modal_open, dev_modal_open
+    contents_list,
+    verify_clicks,
+    classify_clicks,
+    confirm_clicks,
+    cancel_col_clicks,
+    cancel_dev_clicks,
+    confirm_dev_clicks,
+    pathname,
+    filenames_list,
+    dropdown_values,
+    dropdown_ids,
+    file_info,
+    col_modal_open,
+    dev_modal_open,
 ):
     """Single consolidated callback that handles both upload and page restoration"""
 
     ctx = callback_context
 
     # Handle page load restoration FIRST
-    if not ctx.triggered or ctx.triggered[0]['prop_id'] == 'url.pathname':
+    if not ctx.triggered or ctx.triggered[0]["prop_id"] == "url.pathname":
         if pathname == "/file-upload" and _uploaded_data_store:
             print(f"🔄 Restoring upload state for {len(_uploaded_data_store)} files")
 
@@ -468,47 +482,103 @@ def consolidated_upload_callback(
                 cols = len(df.columns)
 
                 upload_results.append(
-                    dbc.Alert([
-                        html.H6([
-                            html.I(className="fas fa-check-circle me-2"),
-                            f"Previously uploaded: {filename}"
-                        ], className="alert-heading"),
-                        html.P(f"📊 {rows:,} rows × {cols} columns"),
-                    ], color="success", className="mb-3")
+                    dbc.Alert(
+                        [
+                            html.H6(
+                                [
+                                    html.I(className="fas fa-check-circle me-2"),
+                                    f"Previously uploaded: {filename}",
+                                ],
+                                className="alert-heading",
+                            ),
+                            html.P(f"📊 {rows:,} rows × {cols} columns"),
+                        ],
+                        color="success",
+                        className="mb-3",
+                    )
                 )
 
                 preview_df = df.head(5)
                 file_preview_components.append(
-                    html.Div([
-                        dbc.Card([
-                            dbc.CardHeader([
-                                html.H6(f"📄 Data Preview: {filename}", className="mb-0")
-                            ]),
-                            dbc.CardBody([
-                                html.H6("First 5 rows:"),
-                                dbc.Table.from_dataframe(  # type: ignore[attr-defined]
-                                    preview_df, striped=True, bordered=True, hover=True, size="sm"
-                                ),
-                                html.Hr(),
-                                html.P([
-                                    html.Strong("Columns: "),
-                                    ", ".join(df.columns.tolist()[:10]),
-                                    "..." if len(df.columns) > 10 else ""
-                                ]),
-                            ])
-                        ], className="mb-3"),
-
-                        dbc.Card([
-                            dbc.CardHeader([html.H6("📋 Data Configuration", className="mb-0")]),
-                            dbc.CardBody([
-                                html.P("Configure your data for analysis:", className="mb-3"),
-                                dbc.ButtonGroup([
-                                    dbc.Button("📋 Verify Columns", id="verify-columns-btn-simple", color="primary", size="sm"),
-                                    dbc.Button("🤖 Classify Devices", id="classify-devices-btn", color="info", size="sm"),
-                                ], className="w-100"),
-                            ])
-                        ], className="mb-3")
-                    ])
+                    html.Div(
+                        [
+                            dbc.Card(
+                                [
+                                    dbc.CardHeader(
+                                        [
+                                            html.H6(
+                                                f"📄 Data Preview: {filename}",
+                                                className="mb-0",
+                                            )
+                                        ]
+                                    ),
+                                    dbc.CardBody(
+                                        [
+                                            html.H6("First 5 rows:"),
+                                            dbc.Table.from_dataframe(  # type: ignore[attr-defined]
+                                                preview_df,
+                                                striped=True,
+                                                bordered=True,
+                                                hover=True,
+                                                size="sm",
+                                            ),
+                                            html.Hr(),
+                                            html.P(
+                                                [
+                                                    html.Strong("Columns: "),
+                                                    ", ".join(df.columns.tolist()[:10]),
+                                                    (
+                                                        "..."
+                                                        if len(df.columns) > 10
+                                                        else ""
+                                                    ),
+                                                ]
+                                            ),
+                                        ]
+                                    ),
+                                ],
+                                className="mb-3",
+                            ),
+                            dbc.Card(
+                                [
+                                    dbc.CardHeader(
+                                        [
+                                            html.H6(
+                                                "📋 Data Configuration",
+                                                className="mb-0",
+                                            )
+                                        ]
+                                    ),
+                                    dbc.CardBody(
+                                        [
+                                            html.P(
+                                                "Configure your data for analysis:",
+                                                className="mb-3",
+                                            ),
+                                            dbc.ButtonGroup(
+                                                [
+                                                    dbc.Button(
+                                                        "📋 Verify Columns",
+                                                        id="verify-columns-btn-simple",
+                                                        color="primary",
+                                                        size="sm",
+                                                    ),
+                                                    dbc.Button(
+                                                        "🤖 Classify Devices",
+                                                        id="classify-devices-btn",
+                                                        color="info",
+                                                        size="sm",
+                                                    ),
+                                                ],
+                                                className="w-100",
+                                            ),
+                                        ]
+                                    ),
+                                ],
+                                className="mb-3",
+                            ),
+                        ]
+                    )
                 )
 
                 current_file_info = {
@@ -516,20 +586,43 @@ def consolidated_upload_callback(
                     "rows": rows,
                     "columns": cols,
                     "column_names": df.columns.tolist(),
-                    "ai_suggestions": get_ai_column_suggestions(df.columns.tolist())
+                    "ai_suggestions": get_ai_column_suggestions(df.columns.tolist()),
                 }
 
-            upload_nav = html.Div([
-                html.Hr(),
-                html.H5("Ready to analyze?"),
-                dbc.Button("🚀 Go to Analytics", href="/analytics", color="success", size="lg")
-            ])
+            upload_nav = html.Div(
+                [
+                    html.Hr(),
+                    html.H5("Ready to analyze?"),
+                    dbc.Button(
+                        "🚀 Go to Analytics",
+                        href="/analytics",
+                        color="success",
+                        size="lg",
+                    ),
+                ]
+            )
 
-            return upload_results, file_preview_components, {}, upload_nav, current_file_info, False, False
+            return (
+                upload_results,
+                file_preview_components,
+                {},
+                upload_nav,
+                current_file_info,
+                False,
+                False,
+            )
 
-        return no_update, no_update, no_update, no_update, no_update, no_update, no_update
+        return (
+            no_update,
+            no_update,
+            no_update,
+            no_update,
+            no_update,
+            no_update,
+            no_update,
+        )
 
-    trigger_id = ctx.triggered[0]['prop_id']
+    trigger_id = ctx.triggered[0]["prop_id"]
     print(f"🎯 Callback triggered by: {trigger_id}")
 
     if "upload-data.contents" in trigger_id and contents_list:
@@ -558,43 +651,100 @@ def consolidated_upload_callback(
                     _uploaded_data_store[filename] = df
 
                     upload_results.append(
-                        dbc.Alert([
-                            html.H6([
-                                html.I(className="fas fa-check-circle me-2"),
-                                f"Successfully uploaded {filename}"
-                            ], className="alert-heading"),
-                            html.P(f"📊 {rows:,} rows × {cols} columns processed"),
-                        ], color="success", className="mb-3")
+                        dbc.Alert(
+                            [
+                                html.H6(
+                                    [
+                                        html.I(className="fas fa-check-circle me-2"),
+                                        f"Successfully uploaded {filename}",
+                                    ],
+                                    className="alert-heading",
+                                ),
+                                html.P(f"📊 {rows:,} rows × {cols} columns processed"),
+                            ],
+                            color="success",
+                            className="mb-3",
+                        )
                     )
 
                     preview_df = df.head(5)
                     file_preview_components.append(
-                        html.Div([
-                            dbc.Card([
-                                dbc.CardHeader([
-                                    html.H6(f"📄 Data Preview: {filename}", className="mb-0")
-                                ]),
-                                dbc.CardBody([
-                                    html.H6("First 5 rows:"),
-                                    dbc.Table.from_dataframe(  # type: ignore[attr-defined]
-                                        preview_df, striped=True, bordered=True, hover=True, size="sm"
-                                    ),
-                                    html.Hr(),
-                                    html.P([html.Strong("Columns: "), ", ".join(df.columns.tolist()[:10])]),
-                                ])
-                            ], className="mb-3"),
-
-                            dbc.Card([
-                                dbc.CardHeader([html.H6("📋 Data Configuration", className="mb-0")]),
-                                dbc.CardBody([
-                                    html.P("Configure your data for analysis:", className="mb-3"),
-                                    dbc.ButtonGroup([
-                                        dbc.Button("📋 Verify Columns", id="verify-columns-btn-simple", color="primary", size="sm"),
-                                        dbc.Button("🤖 Classify Devices", id="classify-devices-btn", color="info", size="sm"),
-                                    ], className="w-100"),
-                                ])
-                            ], className="mb-3")
-                        ])
+                        html.Div(
+                            [
+                                dbc.Card(
+                                    [
+                                        dbc.CardHeader(
+                                            [
+                                                html.H6(
+                                                    f"📄 Data Preview: {filename}",
+                                                    className="mb-0",
+                                                )
+                                            ]
+                                        ),
+                                        dbc.CardBody(
+                                            [
+                                                html.H6("First 5 rows:"),
+                                                dbc.Table.from_dataframe(  # type: ignore[attr-defined]
+                                                    preview_df,
+                                                    striped=True,
+                                                    bordered=True,
+                                                    hover=True,
+                                                    size="sm",
+                                                ),
+                                                html.Hr(),
+                                                html.P(
+                                                    [
+                                                        html.Strong("Columns: "),
+                                                        ", ".join(
+                                                            df.columns.tolist()[:10]
+                                                        ),
+                                                    ]
+                                                ),
+                                            ]
+                                        ),
+                                    ],
+                                    className="mb-3",
+                                ),
+                                dbc.Card(
+                                    [
+                                        dbc.CardHeader(
+                                            [
+                                                html.H6(
+                                                    "📋 Data Configuration",
+                                                    className="mb-0",
+                                                )
+                                            ]
+                                        ),
+                                        dbc.CardBody(
+                                            [
+                                                html.P(
+                                                    "Configure your data for analysis:",
+                                                    className="mb-3",
+                                                ),
+                                                dbc.ButtonGroup(
+                                                    [
+                                                        dbc.Button(
+                                                            "📋 Verify Columns",
+                                                            id="verify-columns-btn-simple",
+                                                            color="primary",
+                                                            size="sm",
+                                                        ),
+                                                        dbc.Button(
+                                                            "🤖 Classify Devices",
+                                                            id="classify-devices-btn",
+                                                            color="info",
+                                                            size="sm",
+                                                        ),
+                                                    ],
+                                                    className="w-100",
+                                                ),
+                                            ]
+                                        ),
+                                    ],
+                                    className="mb-3",
+                                ),
+                            ]
+                        )
                     )
 
                     column_names = df.columns.tolist()
@@ -604,16 +754,19 @@ def consolidated_upload_callback(
                         "columns": cols,
                         "column_names": column_names,
                         "upload_time": result["upload_time"].isoformat(),
-                        "ai_suggestions": get_ai_column_suggestions(column_names)
+                        "ai_suggestions": get_ai_column_suggestions(column_names),
                     }
                     current_file_info = file_info_dict[filename]
 
                 else:
                     upload_results.append(
-                        dbc.Alert([
-                            html.H6("Upload Failed", className="alert-heading"),
-                            html.P(result["error"]),
-                        ], color="danger")
+                        dbc.Alert(
+                            [
+                                html.H6("Upload Failed", className="alert-heading"),
+                                html.P(result["error"]),
+                            ],
+                            color="danger",
+                        )
                     )
 
             except Exception as e:
@@ -623,13 +776,28 @@ def consolidated_upload_callback(
 
         upload_nav = []
         if file_info_dict:
-            upload_nav = html.Div([
-                html.Hr(),
-                html.H5("Ready to analyze?"),
-                dbc.Button("🚀 Go to Analytics", href="/analytics", color="success", size="lg")
-            ])
+            upload_nav = html.Div(
+                [
+                    html.Hr(),
+                    html.H5("Ready to analyze?"),
+                    dbc.Button(
+                        "🚀 Go to Analytics",
+                        href="/analytics",
+                        color="success",
+                        size="lg",
+                    ),
+                ]
+            )
 
-        return upload_results, file_preview_components, file_info_dict, upload_nav, current_file_info, no_update, no_update
+        return (
+            upload_results,
+            file_preview_components,
+            file_info_dict,
+            upload_nav,
+            current_file_info,
+            no_update,
+            no_update,
+        )
 
     elif "verify-columns-btn-simple" in trigger_id and verify_clicks:
         print("🔍 Opening column verification modal...")
@@ -641,15 +809,41 @@ def consolidated_upload_callback(
 
     elif "column-verify-confirm" in trigger_id and confirm_clicks:
         print("✅ Column mappings confirmed")
-        success_alert = dbc.Toast([html.P("✅ Column mappings saved!")],
-                                 header="Saved", is_open=True, dismissable=True, duration=3000)
-        return success_alert, no_update, no_update, no_update, no_update, False, no_update
+        success_alert = dbc.Toast(
+            [html.P("✅ Column mappings saved!")],
+            header="Saved",
+            is_open=True,
+            dismissable=True,
+            duration=3000,
+        )
+        return (
+            success_alert,
+            no_update,
+            no_update,
+            no_update,
+            no_update,
+            False,
+            no_update,
+        )
 
     elif "device-verify-confirm" in trigger_id and confirm_dev_clicks:
         print("✅ Device mappings confirmed")
-        success_alert = dbc.Toast([html.P("✅ Device mappings saved!")],
-                                 header="Saved", is_open=True, dismissable=True, duration=3000)
-        return success_alert, no_update, no_update, no_update, no_update, no_update, False
+        success_alert = dbc.Toast(
+            [html.P("✅ Device mappings saved!")],
+            header="Saved",
+            is_open=True,
+            dismissable=True,
+            duration=3000,
+        )
+        return (
+            success_alert,
+            no_update,
+            no_update,
+            no_update,
+            no_update,
+            no_update,
+            False,
+        )
 
     elif "column-verify-cancel" in trigger_id or "device-verify-cancel" in trigger_id:
         print("❌ Closing modals...")
@@ -777,6 +971,7 @@ def populate_device_modal_with_learning(is_open, file_info):
                     print(f"🤖 DEBUG - Testing AI on sample devices:")
                     try:
                         from services.ai_device_generator import AIDeviceGenerator
+
                         ai_gen = AIDeviceGenerator()
 
                         for device in sample_devices[:5]:  # Test first 5
@@ -1017,6 +1212,92 @@ def populate_modal_content(is_open, file_info):
             ),
         ]
     )
+
+
+@callback(
+    Output("device-learning-status", "children"),
+    [
+        Input("device-verify-confirm", "n_clicks"),
+    ],
+    [
+        State({"type": "device-floor", "index": ALL}, "value"),
+        State({"type": "device-access", "index": ALL}, "value"),
+        State({"type": "device-security", "index": ALL}, "value"),
+        State({"type": "device-name", "index": ALL}, "data"),
+        State("current-file-info-store", "data"),
+    ],
+    prevent_initial_call=True,
+)
+def save_device_mappings_on_confirm(
+    confirm_clicks,
+    floor_values,
+    access_values,
+    security_values,
+    device_names,
+    file_info,
+):
+    """Save device mappings when user confirms"""
+    if not confirm_clicks or not device_names:
+        return ""
+
+    try:
+        from services.consolidated_learning_service import get_learning_service
+
+        # Get uploaded data
+        uploaded_data = get_uploaded_data()
+        if not uploaded_data:
+            return dbc.Alert("No uploaded data to save", color="warning")
+
+        # Use first uploaded file
+        filename = list(uploaded_data.keys())[0]
+        df = uploaded_data[filename]
+
+        # Create device mappings from user inputs
+        device_mappings = {}
+
+        for i, device_name in enumerate(device_names):
+            if device_name and i < len(floor_values):
+                # Get access flags
+                access_flags = access_values[i] if i < len(access_values) else []
+
+                device_mappings[device_name] = {
+                    "device_name": device_name,
+                    "floor_number": floor_values[i] if i < len(floor_values) else 1,
+                    "security_level": (
+                        security_values[i] if i < len(security_values) else 5
+                    ),
+                    "is_entry": "is_entry" in access_flags,
+                    "is_exit": "is_exit" in access_flags,
+                    "is_elevator": "is_elevator" in access_flags,
+                    "is_stairwell": "is_stairwell" in access_flags,
+                    "is_fire_escape": "is_fire_escape" in access_flags,
+                    "confirmed_at": datetime.now().isoformat(),
+                    "manually_edited": True,
+                }
+
+        # Save to learning service
+        learning_service = get_learning_service()
+        fingerprint = learning_service.save_complete_mapping(
+            df, filename, device_mappings
+        )
+
+        print(
+            f"✅ LEARNING: Saved {len(device_mappings)} device mappings with ID: {fingerprint[:8]}"
+        )
+
+        return dbc.Alert(
+            [
+                html.I(className="fas fa-save me-2"),
+                f"✅ Device mappings saved! Learned {len(device_mappings)} devices. ID: {fingerprint[:8]}",
+            ],
+            color="success",
+            dismissable=True,
+            duration=5000,
+        )
+
+    except Exception as e:
+        print(f"❌ LEARNING ERROR: Failed to save mappings: {e}")
+        return dbc.Alert(f"❌ Error saving mappings: {e}", color="danger")
 
 
 # Export functions for integration with other modules


### PR DESCRIPTION
## Summary
- show device-learning-status message in file upload layout
- save device mappings when confirm is clicked

## Testing
- `black pages/file_upload.py`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_685dddb1a950832081605a581bb5282a