### PR TITLE
Check learned mappings before fresh AI analysis

### DIFF
--- a/pages/file_upload.py
+++ b/pages/file_upload.py
@@ -34,13 +34,36 @@ _uploaded_data_store: Dict[str, pd.DataFrame] = {}
 
 
 def analyze_device_name_with_ai(device_name):
-    """Enhanced AI analysis using the new AI generator"""
+    """Enhanced AI analysis that respects learned mappings"""
     try:
+        # FIRST: Check if we have learned mappings for this device
+        from components.simple_device_mapping import _device_ai_mappings
+
+        if device_name in _device_ai_mappings:
+            learned = _device_ai_mappings[device_name]
+            print(f"🧠 Using learned mapping for '{device_name}'")
+
+            # Return learned values instead of fresh AI analysis
+            return {
+                "floor_number": learned.get('floor_number', 1),
+                "security_level": learned.get('security_level', 5),
+                "confidence": learned.get('confidence', 0.95),  # High confidence for learned
+                "is_entry": learned.get('is_entry', False),
+                "is_exit": learned.get('is_exit', False),
+                "is_elevator": learned.get('is_elevator', False),
+                "is_stairwell": learned.get('is_stairwell', False),
+                "is_fire_escape": learned.get('is_fire_escape', False),
+                "device_name": learned.get('device_name', device_name),
+                "ai_reasoning": f"Learned from previous user corrections"
+            }
+
+        # SECOND: If no learned mapping, use fresh AI analysis
         from services.ai_device_generator import AIDeviceGenerator
 
-        # Use our enhanced AI generator
         ai_gen = AIDeviceGenerator()
         result = ai_gen.generate_device_attributes(str(device_name))
+
+        print(f"🤖 Using fresh AI analysis for '{device_name}'")
 
         # Convert to format expected by the UI
         return {
@@ -53,7 +76,7 @@ def analyze_device_name_with_ai(device_name):
             "is_stairwell": result.is_stairwell,
             "is_fire_escape": result.is_fire_escape,
             "device_name": result.device_name,
-            "ai_reasoning": result.ai_reasoning,
+            "ai_reasoning": result.ai_reasoning
         }
 
     except Exception as e:
@@ -69,7 +92,7 @@ def analyze_device_name_with_ai(device_name):
             "is_stairwell": False,
             "is_fire_escape": False,
             "device_name": str(device_name),
-            "ai_reasoning": "Error in AI analysis - using defaults",
+            "ai_reasoning": "Error in analysis - using defaults"
         }
 
 

--- a/tests/test_learning_priority.py
+++ b/tests/test_learning_priority.py
@@ -1,0 +1,51 @@
+import pytest
+from pages.file_upload import analyze_device_name_with_ai
+from components.simple_device_mapping import _device_ai_mappings
+from services.ai_device_generator import AIDeviceGenerator, DeviceAttributes
+
+class DummyAttrs:
+    def __init__(self):
+        self.floor_number = 3
+        self.security_level = 4
+        self.confidence = 0.7
+        self.is_entry = False
+        self.is_exit = True
+        self.is_elevator = False
+        self.is_stairwell = False
+        self.is_fire_escape = True
+        self.device_name = "Dummy"
+        self.ai_reasoning = "dummy"
+
+def test_learned_mapping_priority(monkeypatch):
+    """Ensure learned mappings are used before invoking AI"""
+    _device_ai_mappings.clear()
+    _device_ai_mappings['door_1'] = {
+        'floor_number': 2,
+        'security_level': 7,
+        'confidence': 0.95,
+        'is_entry': True,
+        'device_name': 'Door 1'
+    }
+
+    def fail_generate(self, *args, **kwargs):
+        raise AssertionError('AI should not be called')
+    monkeypatch.setattr(AIDeviceGenerator, 'generate_device_attributes', fail_generate)
+
+    result = analyze_device_name_with_ai('door_1')
+    assert result['floor_number'] == 2
+    assert result['security_level'] == 7
+    assert result['is_entry'] is True
+    assert result['device_name'] == 'Door 1'
+
+
+def test_fallback_to_ai(monkeypatch):
+    """If no learned mapping exists, AI generator should be used"""
+    _device_ai_mappings.clear()
+
+    def fake_generate(self, name):
+        return DummyAttrs()
+    monkeypatch.setattr(AIDeviceGenerator, 'generate_device_attributes', fake_generate)
+
+    result = analyze_device_name_with_ai('unknown_door')
+    assert result['floor_number'] == 3
+    assert result['is_exit'] is True


### PR DESCRIPTION
## Summary
- prioritize learned device mappings in `analyze_device_name_with_ai`
- add tests verifying learned mappings override new AI analysis

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_685de2049e3c83208d7937a91a558325