### PR TITLE
Persist device mappings on confirm

### DIFF
--- a/pages/file_upload.py
+++ b/pages/file_upload.py
@@ -22,6 +22,7 @@ from services.device_learning_service import DeviceLearningService
 from components.column_verification import (
     save_verified_mappings,
 )
+from components.simple_device_mapping import save_confirmed_device_mappings
 
 
 logger = logging.getLogger(__name__)
@@ -46,9 +47,12 @@ def analyze_device_name_with_ai(device_name):
                 return mapping
 
         # Only use AI if no user mapping exists
-        print(f"\U0001f916 No user mapping found, generating AI analysis for '{device_name}'")
+        print(
+            f"\U0001f916 No user mapping found, generating AI analysis for '{device_name}'"
+        )
 
         from services.ai_device_generator import AIDeviceGenerator
+
         ai_generator = AIDeviceGenerator()
         result = ai_generator.generate_device_attributes(device_name)
 
@@ -418,6 +422,8 @@ def highlight_upload_area(n_clicks):
         "cursor": "pointer",
         "backgroundColor": "#f8f9fa",
     }
+
+
 @callback(
     [
         Output("upload-results", "children"),
@@ -449,17 +455,27 @@ def highlight_upload_area(n_clicks):
     prevent_initial_call=False,
 )
 def consolidated_upload_callback(
-    contents_list, verify_clicks, classify_clicks, confirm_clicks,
-    cancel_col_clicks, cancel_dev_clicks, confirm_dev_clicks, pathname,
-    filenames_list, dropdown_values, dropdown_ids, file_info,
-    col_modal_open, dev_modal_open
+    contents_list,
+    verify_clicks,
+    classify_clicks,
+    confirm_clicks,
+    cancel_col_clicks,
+    cancel_dev_clicks,
+    confirm_dev_clicks,
+    pathname,
+    filenames_list,
+    dropdown_values,
+    dropdown_ids,
+    file_info,
+    col_modal_open,
+    dev_modal_open,
 ):
     """Single consolidated callback that handles both upload and page restoration"""
 
     ctx = callback_context
 
     # Handle page load restoration FIRST
-    if not ctx.triggered or ctx.triggered[0]['prop_id'] == 'url.pathname':
+    if not ctx.triggered or ctx.triggered[0]["prop_id"] == "url.pathname":
         if pathname == "/file-upload" and _uploaded_data_store:
             print(f"🔄 Restoring upload state for {len(_uploaded_data_store)} files")
 
@@ -472,47 +488,103 @@ def consolidated_upload_callback(
                 cols = len(df.columns)
 
                 upload_results.append(
-                    dbc.Alert([
-                        html.H6([
-                            html.I(className="fas fa-check-circle me-2"),
-                            f"Previously uploaded: {filename}"
-                        ], className="alert-heading"),
-                        html.P(f"📊 {rows:,} rows × {cols} columns"),
-                    ], color="success", className="mb-3")
+                    dbc.Alert(
+                        [
+                            html.H6(
+                                [
+                                    html.I(className="fas fa-check-circle me-2"),
+                                    f"Previously uploaded: {filename}",
+                                ],
+                                className="alert-heading",
+                            ),
+                            html.P(f"📊 {rows:,} rows × {cols} columns"),
+                        ],
+                        color="success",
+                        className="mb-3",
+                    )
                 )
 
                 preview_df = df.head(5)
                 file_preview_components.append(
-                    html.Div([
-                        dbc.Card([
-                            dbc.CardHeader([
-                                html.H6(f"📄 Data Preview: {filename}", className="mb-0")
-                            ]),
-                            dbc.CardBody([
-                                html.H6("First 5 rows:"),
-                                dbc.Table.from_dataframe(  # type: ignore[attr-defined]
-                                    preview_df, striped=True, bordered=True, hover=True, size="sm"
-                                ),
-                                html.Hr(),
-                                html.P([
-                                    html.Strong("Columns: "),
-                                    ", ".join(df.columns.tolist()[:10]),
-                                    "..." if len(df.columns) > 10 else ""
-                                ]),
-                            ])
-                        ], className="mb-3"),
-
-                        dbc.Card([
-                            dbc.CardHeader([html.H6("📋 Data Configuration", className="mb-0")]),
-                            dbc.CardBody([
-                                html.P("Configure your data for analysis:", className="mb-3"),
-                                dbc.ButtonGroup([
-                                    dbc.Button("📋 Verify Columns", id="verify-columns-btn-simple", color="primary", size="sm"),
-                                    dbc.Button("🤖 Classify Devices", id="classify-devices-btn", color="info", size="sm"),
-                                ], className="w-100"),
-                            ])
-                        ], className="mb-3")
-                    ])
+                    html.Div(
+                        [
+                            dbc.Card(
+                                [
+                                    dbc.CardHeader(
+                                        [
+                                            html.H6(
+                                                f"📄 Data Preview: {filename}",
+                                                className="mb-0",
+                                            )
+                                        ]
+                                    ),
+                                    dbc.CardBody(
+                                        [
+                                            html.H6("First 5 rows:"),
+                                            dbc.Table.from_dataframe(  # type: ignore[attr-defined]
+                                                preview_df,
+                                                striped=True,
+                                                bordered=True,
+                                                hover=True,
+                                                size="sm",
+                                            ),
+                                            html.Hr(),
+                                            html.P(
+                                                [
+                                                    html.Strong("Columns: "),
+                                                    ", ".join(df.columns.tolist()[:10]),
+                                                    (
+                                                        "..."
+                                                        if len(df.columns) > 10
+                                                        else ""
+                                                    ),
+                                                ]
+                                            ),
+                                        ]
+                                    ),
+                                ],
+                                className="mb-3",
+                            ),
+                            dbc.Card(
+                                [
+                                    dbc.CardHeader(
+                                        [
+                                            html.H6(
+                                                "📋 Data Configuration",
+                                                className="mb-0",
+                                            )
+                                        ]
+                                    ),
+                                    dbc.CardBody(
+                                        [
+                                            html.P(
+                                                "Configure your data for analysis:",
+                                                className="mb-3",
+                                            ),
+                                            dbc.ButtonGroup(
+                                                [
+                                                    dbc.Button(
+                                                        "📋 Verify Columns",
+                                                        id="verify-columns-btn-simple",
+                                                        color="primary",
+                                                        size="sm",
+                                                    ),
+                                                    dbc.Button(
+                                                        "🤖 Classify Devices",
+                                                        id="classify-devices-btn",
+                                                        color="info",
+                                                        size="sm",
+                                                    ),
+                                                ],
+                                                className="w-100",
+                                            ),
+                                        ]
+                                    ),
+                                ],
+                                className="mb-3",
+                            ),
+                        ]
+                    )
                 )
 
                 current_file_info = {
@@ -520,20 +592,43 @@ def consolidated_upload_callback(
                     "rows": rows,
                     "columns": cols,
                     "column_names": df.columns.tolist(),
-                    "ai_suggestions": get_ai_column_suggestions(df.columns.tolist())
+                    "ai_suggestions": get_ai_column_suggestions(df.columns.tolist()),
                 }
 
-            upload_nav = html.Div([
-                html.Hr(),
-                html.H5("Ready to analyze?"),
-                dbc.Button("🚀 Go to Analytics", href="/analytics", color="success", size="lg")
-            ])
+            upload_nav = html.Div(
+                [
+                    html.Hr(),
+                    html.H5("Ready to analyze?"),
+                    dbc.Button(
+                        "🚀 Go to Analytics",
+                        href="/analytics",
+                        color="success",
+                        size="lg",
+                    ),
+                ]
+            )
 
-            return upload_results, file_preview_components, {}, upload_nav, current_file_info, False, False
+            return (
+                upload_results,
+                file_preview_components,
+                {},
+                upload_nav,
+                current_file_info,
+                False,
+                False,
+            )
 
-        return no_update, no_update, no_update, no_update, no_update, no_update, no_update
+        return (
+            no_update,
+            no_update,
+            no_update,
+            no_update,
+            no_update,
+            no_update,
+            no_update,
+        )
 
-    trigger_id = ctx.triggered[0]['prop_id']
+    trigger_id = ctx.triggered[0]["prop_id"]
     print(f"🎯 Callback triggered by: {trigger_id}")
 
     if "upload-data.contents" in trigger_id and contents_list:
@@ -562,43 +657,100 @@ def consolidated_upload_callback(
                     _uploaded_data_store[filename] = df
 
                     upload_results.append(
-                        dbc.Alert([
-                            html.H6([
-                                html.I(className="fas fa-check-circle me-2"),
-                                f"Successfully uploaded {filename}"
-                            ], className="alert-heading"),
-                            html.P(f"📊 {rows:,} rows × {cols} columns processed"),
-                        ], color="success", className="mb-3")
+                        dbc.Alert(
+                            [
+                                html.H6(
+                                    [
+                                        html.I(className="fas fa-check-circle me-2"),
+                                        f"Successfully uploaded {filename}",
+                                    ],
+                                    className="alert-heading",
+                                ),
+                                html.P(f"📊 {rows:,} rows × {cols} columns processed"),
+                            ],
+                            color="success",
+                            className="mb-3",
+                        )
                     )
 
                     preview_df = df.head(5)
                     file_preview_components.append(
-                        html.Div([
-                            dbc.Card([
-                                dbc.CardHeader([
-                                    html.H6(f"📄 Data Preview: {filename}", className="mb-0")
-                                ]),
-                                dbc.CardBody([
-                                    html.H6("First 5 rows:"),
-                                    dbc.Table.from_dataframe(  # type: ignore[attr-defined]
-                                        preview_df, striped=True, bordered=True, hover=True, size="sm"
-                                    ),
-                                    html.Hr(),
-                                    html.P([html.Strong("Columns: "), ", ".join(df.columns.tolist()[:10])]),
-                                ])
-                            ], className="mb-3"),
-
-                            dbc.Card([
-                                dbc.CardHeader([html.H6("📋 Data Configuration", className="mb-0")]),
-                                dbc.CardBody([
-                                    html.P("Configure your data for analysis:", className="mb-3"),
-                                    dbc.ButtonGroup([
-                                        dbc.Button("📋 Verify Columns", id="verify-columns-btn-simple", color="primary", size="sm"),
-                                        dbc.Button("🤖 Classify Devices", id="classify-devices-btn", color="info", size="sm"),
-                                    ], className="w-100"),
-                                ])
-                            ], className="mb-3")
-                        ])
+                        html.Div(
+                            [
+                                dbc.Card(
+                                    [
+                                        dbc.CardHeader(
+                                            [
+                                                html.H6(
+                                                    f"📄 Data Preview: {filename}",
+                                                    className="mb-0",
+                                                )
+                                            ]
+                                        ),
+                                        dbc.CardBody(
+                                            [
+                                                html.H6("First 5 rows:"),
+                                                dbc.Table.from_dataframe(  # type: ignore[attr-defined]
+                                                    preview_df,
+                                                    striped=True,
+                                                    bordered=True,
+                                                    hover=True,
+                                                    size="sm",
+                                                ),
+                                                html.Hr(),
+                                                html.P(
+                                                    [
+                                                        html.Strong("Columns: "),
+                                                        ", ".join(
+                                                            df.columns.tolist()[:10]
+                                                        ),
+                                                    ]
+                                                ),
+                                            ]
+                                        ),
+                                    ],
+                                    className="mb-3",
+                                ),
+                                dbc.Card(
+                                    [
+                                        dbc.CardHeader(
+                                            [
+                                                html.H6(
+                                                    "📋 Data Configuration",
+                                                    className="mb-0",
+                                                )
+                                            ]
+                                        ),
+                                        dbc.CardBody(
+                                            [
+                                                html.P(
+                                                    "Configure your data for analysis:",
+                                                    className="mb-3",
+                                                ),
+                                                dbc.ButtonGroup(
+                                                    [
+                                                        dbc.Button(
+                                                            "📋 Verify Columns",
+                                                            id="verify-columns-btn-simple",
+                                                            color="primary",
+                                                            size="sm",
+                                                        ),
+                                                        dbc.Button(
+                                                            "🤖 Classify Devices",
+                                                            id="classify-devices-btn",
+                                                            color="info",
+                                                            size="sm",
+                                                        ),
+                                                    ],
+                                                    className="w-100",
+                                                ),
+                                            ]
+                                        ),
+                                    ],
+                                    className="mb-3",
+                                ),
+                            ]
+                        )
                     )
 
                     column_names = df.columns.tolist()
@@ -608,35 +760,48 @@ def consolidated_upload_callback(
                         "columns": cols,
                         "column_names": column_names,
                         "upload_time": result["upload_time"].isoformat(),
-                        "ai_suggestions": get_ai_column_suggestions(column_names)
+                        "ai_suggestions": get_ai_column_suggestions(column_names),
                     }
                     current_file_info = file_info_dict[filename]
 
                     # Load saved mappings on first upload - SIMPLE FIX
                     try:
-                        user_mappings = learning_service.get_user_device_mappings(filename)
+                        user_mappings = learning_service.get_user_device_mappings(
+                            filename
+                        )
                         if user_mappings:
-                            from components.simple_device_mapping import _device_ai_mappings
+                            from components.simple_device_mapping import (
+                                _device_ai_mappings,
+                            )
+
                             _device_ai_mappings.clear()
                             # Mark all as user_confirmed to override AI
                             for device, mapping in user_mappings.items():
                                 mapping["source"] = "user_confirmed"
                                 _device_ai_mappings[device] = mapping
-                            print(f"✅ Loaded {len(user_mappings)} saved mappings - AI SKIPPED")
+                            print(
+                                f"✅ Loaded {len(user_mappings)} saved mappings - AI SKIPPED"
+                            )
                         else:
                             print(f"🆕 First upload - AI will be used")
                             # Clear any stale mappings
-                            from components.simple_device_mapping import _device_ai_mappings
+                            from components.simple_device_mapping import (
+                                _device_ai_mappings,
+                            )
+
                             _device_ai_mappings.clear()
                     except Exception as e:
                         print(f"⚠️ Error: {e}")
 
                 else:
                     upload_results.append(
-                        dbc.Alert([
-                            html.H6("Upload Failed", className="alert-heading"),
-                            html.P(result["error"]),
-                        ], color="danger")
+                        dbc.Alert(
+                            [
+                                html.H6("Upload Failed", className="alert-heading"),
+                                html.P(result["error"]),
+                            ],
+                            color="danger",
+                        )
                     )
 
             except Exception as e:
@@ -646,13 +811,28 @@ def consolidated_upload_callback(
 
         upload_nav = []
         if file_info_dict:
-            upload_nav = html.Div([
-                html.Hr(),
-                html.H5("Ready to analyze?"),
-                dbc.Button("🚀 Go to Analytics", href="/analytics", color="success", size="lg")
-            ])
+            upload_nav = html.Div(
+                [
+                    html.Hr(),
+                    html.H5("Ready to analyze?"),
+                    dbc.Button(
+                        "🚀 Go to Analytics",
+                        href="/analytics",
+                        color="success",
+                        size="lg",
+                    ),
+                ]
+            )
 
-        return upload_results, file_preview_components, file_info_dict, upload_nav, current_file_info, no_update, no_update
+        return (
+            upload_results,
+            file_preview_components,
+            file_info_dict,
+            upload_nav,
+            current_file_info,
+            no_update,
+            no_update,
+        )
 
     elif "verify-columns-btn-simple" in trigger_id and verify_clicks:
         print("🔍 Opening column verification modal...")
@@ -664,10 +844,22 @@ def consolidated_upload_callback(
 
     elif "column-verify-confirm" in trigger_id and confirm_clicks:
         print("✅ Column mappings confirmed")
-        success_alert = dbc.Toast([html.P("✅ Column mappings saved!")],
-                                 header="Saved", is_open=True, dismissable=True, duration=3000)
-        return success_alert, no_update, no_update, no_update, no_update, False, no_update
-
+        success_alert = dbc.Toast(
+            [html.P("✅ Column mappings saved!")],
+            header="Saved",
+            is_open=True,
+            dismissable=True,
+            duration=3000,
+        )
+        return (
+            success_alert,
+            no_update,
+            no_update,
+            no_update,
+            no_update,
+            False,
+            no_update,
+        )
 
     elif "column-verify-cancel" in trigger_id or "device-verify-cancel" in trigger_id:
         print("❌ Closing modals...")
@@ -795,6 +987,7 @@ def populate_device_modal_with_learning(is_open, file_info):
                     print(f"🤖 DEBUG - Testing AI on sample devices:")
                     try:
                         from services.ai_device_generator import AIDeviceGenerator
+
                         ai_gen = AIDeviceGenerator()
 
                         for device in sample_devices[:5]:  # Test first 5
@@ -1038,19 +1231,25 @@ def populate_modal_content(is_open, file_info):
 
 
 @callback(
-    [Output("toast-container", "children", allow_duplicate=True),
-     Output("column-verification-modal", "is_open", allow_duplicate=True),
-     Output("device-verification-modal", "is_open", allow_duplicate=True)],
+    [
+        Output("toast-container", "children", allow_duplicate=True),
+        Output("column-verification-modal", "is_open", allow_duplicate=True),
+        Output("device-verification-modal", "is_open", allow_duplicate=True),
+    ],
     [Input("device-verify-confirm", "n_clicks")],
-    [State({"type": "device-floor", "index": ALL}, "value"),
-     State({"type": "device-security", "index": ALL}, "value"),
-     State({"type": "device-access", "index": ALL}, "value"),
-     State({"type": "device-special", "index": ALL}, "value"),
-     State("current-file-info-store", "data")],
+    [
+        State({"type": "device-floor", "index": ALL}, "value"),
+        State({"type": "device-security", "index": ALL}, "value"),
+        State({"type": "device-access", "index": ALL}, "value"),
+        State({"type": "device-special", "index": ALL}, "value"),
+        State("current-file-info-store", "data"),
+    ],
     prevent_initial_call=True,
 )
-def save_confirmed_device_mappings(confirm_clicks, floors, security, access, special, file_info):
-    """Save confirmed device mappings to database"""
+def device_confirm_callback(
+    confirm_clicks, floors, security, access, special, file_info
+):
+    """Persist confirmed device mappings to database"""
     if not confirm_clicks or not file_info:
         return no_update, no_update, no_update
 
@@ -1066,21 +1265,26 @@ def save_confirmed_device_mappings(confirm_clicks, floors, security, access, spe
                 "security_level": security[i] if i < len(security) else 5,
                 "is_entry": "entry" in (access[i] if i < len(access) else []),
                 "is_exit": "exit" in (access[i] if i < len(access) else []),
-                "is_restricted": "is_restricted" in (special[i] if i < len(special) else []),  # ADD THIS
+                "is_restricted": "is_restricted"
+                in (special[i] if i < len(special) else []),  # ADD THIS
                 "confidence": 1.0,
                 "device_name": device,
                 "source": "user_confirmed",
                 "saved_at": datetime.now().isoformat(),
             }
 
-        # Save to learning service database
-        learning_service.save_user_device_mappings(filename, user_mappings)
-
-        # Update global mappings
         from components.simple_device_mapping import _device_ai_mappings
+
         _device_ai_mappings.update(user_mappings)
 
-        print(f"\u2705 Saved {len(user_mappings)} confirmed device mappings to database")
+        try:
+            df = _uploaded_data_store.get(filename)
+            fingerprint = save_confirmed_device_mappings(
+                df, filename, _device_ai_mappings
+            )
+            print(f"\u2705 Saved manual device mappings (fingerprint={fingerprint})")
+        except Exception as e:
+            print(f"❌ Error saving manual device mappings: {e}")
 
         success_alert = dbc.Toast(
             "✅ Device mappings saved to database!",

--- a/services/door_mapping_service.py
+++ b/services/door_mapping_service.py
@@ -2,6 +2,7 @@
 Door Mapping Service - Business logic for device attribute assignment
 Handles AI model data processing and manual override management
 """
+
 import pandas as pd
 import json
 import logging
@@ -19,6 +20,7 @@ logger = logging.getLogger(__name__)
 @dataclass
 class DeviceAttributeData:
     """Device attribute data structure"""
+
     door_id: str
     name: str
     entry: bool = False
@@ -36,58 +38,60 @@ class DeviceAttributeData:
 
 class DoorMappingService:
     """Service for handling door mapping and device attribute assignment"""
-    
+
     def __init__(self):
         self.ai_model_version = "v2.3"
         self.confidence_threshold = 75
-        
-    def process_uploaded_data(self, df: pd.DataFrame, client_profile: str = "auto") -> Dict[str, Any]:
+
+    def process_uploaded_data(
+        self, df: pd.DataFrame, client_profile: str = "auto"
+    ) -> Dict[str, Any]:
         """
         Process uploaded CSV/JSON/Excel data and generate device attribute assignments
-        
+
         Args:
             df: Uploaded data as pandas DataFrame
             client_profile: Client configuration profile
-            
+
         Returns:
             Dict containing processed device data and metadata
         """
         try:
             # Validate required columns
-            required_columns = ['door_id']
+            required_columns = ["door_id"]
             missing_columns = [col for col in required_columns if col not in df.columns]
-            
+
             if missing_columns:
                 raise ValueError(f"Missing required columns: {missing_columns}")
-            
+
             # Extract unique devices
-            unique_doors = df['door_id'].unique()
-            
+            unique_doors = df["door_id"].unique()
+
             # Generate AI attribute assignments
             devices_data = []
             for door_id in unique_doors:
                 device_data = self._generate_ai_attributes(door_id, df, client_profile)
                 devices_data.append(device_data)
-            
+
             # Prepare response
             response = {
-                'devices': [device.__dict__ for device in devices_data],
-                'metadata': {
-                    'total_devices': len(devices_data),
-                    'ai_model_version': self.ai_model_version,
-                    'client_profile': client_profile,
-                    'processing_timestamp': datetime.now().isoformat(),
-                    'confidence_threshold': self.confidence_threshold
-                }
+                "devices": [device.__dict__ for device in devices_data],
+                "metadata": {
+                    "total_devices": len(devices_data),
+                    "ai_model_version": self.ai_model_version,
+                    "client_profile": client_profile,
+                    "processing_timestamp": datetime.now().isoformat(),
+                    "confidence_threshold": self.confidence_threshold,
+                },
             }
-            
+
             logger.info(f"Processed {len(devices_data)} devices for door mapping")
             return response
-            
+
         except Exception as e:
             logger.error(f"Error processing uploaded data: {e}")
             raise
-    
+
     def _generate_ai_attributes(
         self, door_id: str, df: pd.DataFrame, client_profile: str
     ) -> DeviceAttributeData:
@@ -133,129 +137,148 @@ class DoorMappingService:
             ai_generated=True,
             manually_edited=False,
         )
-    
+
     def _generate_device_name(self, door_id: str, device_rows: pd.DataFrame) -> str:
         """Generate a human-readable device name"""
         # Clean up door_id and make it more readable
-        name = door_id.replace('_', ' ').replace('-', ' ')
-        
+        name = door_id.replace("_", " ").replace("-", " ")
+
         # Capitalize words
-        name = ' '.join(word.capitalize() for word in name.split())
-        
+        name = " ".join(word.capitalize() for word in name.split())
+
         # Add context if available from data
         if len(device_rows) > 0:
             # Check for common patterns in access data
-            if any('entry' in str(device_rows.iloc[0]).lower() for _ in [True]):
+            if any("entry" in str(device_rows.iloc[0]).lower() for _ in [True]):
                 pass  # Keep name as is
-        
+
         return name
-    
-    def _analyze_door_patterns(self, door_id: str, device_rows: pd.DataFrame, client_profile: str) -> Dict[str, Any]:
+
+    def _analyze_door_patterns(
+        self, door_id: str, device_rows: pd.DataFrame, client_profile: str
+    ) -> Dict[str, Any]:
         """
         Analyze door ID patterns to determine likely attributes
-        
+
         This is where the AI model logic would go. For now, using rule-based patterns.
         """
         door_id_lower = door_id.lower()
         attributes = {
-            'entry': False,
-            'exit': False,
-            'elevator': False,
-            'stairwell': False,
-            'fire_escape': False,
-            'other': False,
-            'security_level': 50
+            "entry": False,
+            "exit": False,
+            "elevator": False,
+            "stairwell": False,
+            "fire_escape": False,
+            "other": False,
+            "security_level": 50,
         }
-        
+
         # Pattern matching for door types
-        if any(keyword in door_id_lower for keyword in ['entry', 'entrance', 'front', 'main']):
-            attributes['entry'] = True
-            attributes['security_level'] = 70
-            
-        if any(keyword in door_id_lower for keyword in ['exit', 'back', 'rear', 'emergency']):
-            attributes['exit'] = True
-            attributes['security_level'] = 60
-            
-        if any(keyword in door_id_lower for keyword in ['elevator', 'lift', 'elev']):
-            attributes['elevator'] = True
-            attributes['security_level'] = 40
-            
-        if any(keyword in door_id_lower for keyword in ['stair', 'stairwell', 'stairs']):
-            attributes['stairwell'] = True
-            attributes['security_level'] = 55
-            
-        if any(keyword in door_id_lower for keyword in ['fire', 'emergency', 'escape']):
-            attributes['fire_escape'] = True
-            attributes['security_level'] = 80
-            
+        if any(
+            keyword in door_id_lower
+            for keyword in ["entry", "entrance", "front", "main"]
+        ):
+            attributes["entry"] = True
+            attributes["security_level"] = 70
+
+        if any(
+            keyword in door_id_lower
+            for keyword in ["exit", "back", "rear", "emergency"]
+        ):
+            attributes["exit"] = True
+            attributes["security_level"] = 60
+
+        if any(keyword in door_id_lower for keyword in ["elevator", "lift", "elev"]):
+            attributes["elevator"] = True
+            attributes["security_level"] = 40
+
+        if any(
+            keyword in door_id_lower for keyword in ["stair", "stairwell", "stairs"]
+        ):
+            attributes["stairwell"] = True
+            attributes["security_level"] = 55
+
+        if any(keyword in door_id_lower for keyword in ["fire", "emergency", "escape"]):
+            attributes["fire_escape"] = True
+            attributes["security_level"] = 80
+
         # If no specific pattern matched, mark as other
-        if not any(attributes[key] for key in ['entry', 'exit', 'elevator', 'stairwell', 'fire_escape']):
-            attributes['other'] = True
-            
+        if not any(
+            attributes[key]
+            for key in ["entry", "exit", "elevator", "stairwell", "fire_escape"]
+        ):
+            attributes["other"] = True
+
         # Adjust security levels based on client profile
         if client_profile == "high_security":
-            attributes['security_level'] = min(100, attributes['security_level'] + 20)
+            attributes["security_level"] = min(100, attributes["security_level"] + 20)
         elif client_profile == "low_security":
-            attributes['security_level'] = max(0, attributes['security_level'] - 20)
-            
+            attributes["security_level"] = max(0, attributes["security_level"] - 20)
+
         return attributes
-    
-    def _calculate_confidence_score(self, door_id: str, attributes: Dict[str, Any], device_rows: pd.DataFrame) -> int:
+
+    def _calculate_confidence_score(
+        self, door_id: str, attributes: Dict[str, Any], device_rows: pd.DataFrame
+    ) -> int:
         """Calculate confidence score for AI-generated attributes"""
         confidence = 50  # Base confidence
-        
+
         # Increase confidence for clear patterns
         door_id_lower = door_id.lower()
-        clear_patterns = ['entry', 'exit', 'elevator', 'stair', 'fire', 'emergency']
-        
+        clear_patterns = ["entry", "exit", "elevator", "stair", "fire", "emergency"]
+
         for pattern in clear_patterns:
             if pattern in door_id_lower:
                 confidence += 15
-                
+
         # Increase confidence based on data volume
         if len(device_rows) > 100:
             confidence += 10
         elif len(device_rows) > 50:
             confidence += 5
-            
+
         # Cap at 95% (never 100% to indicate AI uncertainty)
         return min(95, confidence)
-    
-    def apply_manual_edits(self, original_data: List[Dict], manual_edits: Dict[str, Dict]) -> List[Dict]:
+
+    def apply_manual_edits(
+        self, original_data: List[Dict], manual_edits: Dict[str, Dict]
+    ) -> List[Dict]:
         """
         Apply manual edits to device data
-        
+
         Args:
             original_data: Original AI-generated device data
             manual_edits: Manual edits per device
-            
+
         Returns:
             Updated device data with manual edits applied
         """
         updated_data = []
-        
+
         for device in original_data:
-            device_id = device['door_id']
-            
+            device_id = device["door_id"]
+
             # Create a copy of the device data
             updated_device = device.copy()
-            
+
             # Apply manual edits if they exist
             if device_id in manual_edits:
                 edits = manual_edits[device_id]
-                
+
                 # Update attributes
                 for attr, value in edits.items():
                     if attr in updated_device:
                         updated_device[attr] = value
-                        
+
                 # Mark as manually edited
-                updated_device['manually_edited'] = True
-                updated_device['edit_timestamp'] = datetime.now().isoformat()
-                updated_device['confidence'] = None  # Clear AI confidence for manual edits
-                
+                updated_device["manually_edited"] = True
+                updated_device["edit_timestamp"] = datetime.now().isoformat()
+                updated_device["confidence"] = (
+                    None  # Clear AI confidence for manual edits
+                )
+
             updated_data.append(updated_device)
-            
+
         return updated_data
 
     def save_verified_mapping(self, mapping_data: Dict[str, Any], user_id: str) -> bool:
@@ -271,14 +294,14 @@ class DoorMappingService:
         """
         try:
             mapping_record = {
-                'user_id': user_id,
-                'timestamp_col': mapping_data.get('timestamp'),
-                'device_col': mapping_data.get('device_name'),
-                'user_col': mapping_data.get('token_id'),
-                'event_type_col': mapping_data.get('event_type'),
-                'floor_estimate': mapping_data.get('floors', 1),
-                'verified_at': datetime.now().isoformat(),
-                'ai_model_version': self.ai_model_version
+                "user_id": user_id,
+                "timestamp_col": mapping_data.get("timestamp"),
+                "device_col": mapping_data.get("device_name"),
+                "user_col": mapping_data.get("token_id"),
+                "event_type_col": mapping_data.get("event_type"),
+                "floor_estimate": mapping_data.get("floors", 1),
+                "verified_at": datetime.now().isoformat(),
+                "ai_model_version": self.ai_model_version,
             }
 
             # Store in your preferred storage system
@@ -290,37 +313,89 @@ class DoorMappingService:
         except Exception as e:
             logger.error(f"Error saving verified mapping: {e}")
             return False
-    
-    def save_manual_edits_for_training(self, manual_edits: Dict[str, Dict], original_data: List[Dict]):
+
+    def save_manual_edits_for_training(
+        self, manual_edits: Dict[str, Dict], original_data: List[Dict]
+    ):
         """
         Save manual edits to improve AI model training
-        
+
         This would typically save to a training database for model improvement
         """
         try:
             training_data = {
-                'timestamp': datetime.now().isoformat(),
-                'ai_model_version': self.ai_model_version,
-                'manual_edits': manual_edits,
-                'original_ai_predictions': original_data,
-                'edit_count': len(manual_edits)
+                "timestamp": datetime.now().isoformat(),
+                "ai_model_version": self.ai_model_version,
+                "manual_edits": manual_edits,
+                "original_ai_predictions": original_data,
+                "edit_count": len(manual_edits),
             }
-            
+
             # Here you would save to your training database
             # For now, just log the information
             logger.info(f"Saved {len(manual_edits)} manual edits for AI training")
-            
+
             return training_data
-            
+
         except Exception as e:
             logger.error(f"Error saving manual edits for training: {e}")
             raise
 
     def apply_learned_mappings(self, df: pd.DataFrame, filename: str) -> bool:
-        """Apply previously learned device mappings if available"""
+        """Apply AI defaults and manual overrides to the DataFrame."""
         try:
+            if "door_id" not in df.columns:
+                logger.warning("No door_id column found; cannot apply mappings")
+                return False
+
+            # 1) Generate AI defaults for each door
+            ai_defaults = {}
+            for door_id in df["door_id"].unique():
+                attrs = self._generate_ai_attributes(door_id, df, "auto").__dict__
+                ai_defaults[door_id] = attrs
+
+            # 2) Fetch manual overrides from learning service
             learning_service = get_learning_service()
-            return learning_service.apply_to_global_store(df, filename)
+            learned = learning_service.get_learned_mappings(df, filename)
+            overrides = learned.get("device_mappings", {})
+
+            # 3) Merge overrides onto AI defaults
+            merged = {k: v.copy() for k, v in ai_defaults.items()}
+            for door_id, attrs in overrides.items():
+                if door_id in merged:
+                    merged[door_id].update(attrs)
+                else:
+                    merged[door_id] = attrs
+
+            # 4) Apply merged attributes to DataFrame
+            for idx, row in df.iterrows():
+                door_id = row.get("door_id")
+                if door_id in merged:
+                    attrs = merged[door_id]
+                    for col, val in {
+                        "floor_number": attrs.get("floor_number"),
+                        "security_level": attrs.get("security_level"),
+                        "is_entry": (
+                            attrs.get("entry")
+                            if "entry" in attrs
+                            else attrs.get("is_entry")
+                        ),
+                        "is_exit": (
+                            attrs.get("exit")
+                            if "exit" in attrs
+                            else attrs.get("is_exit")
+                        ),
+                        "is_elevator": attrs.get("elevator", attrs.get("is_elevator")),
+                        "is_stairwell": attrs.get(
+                            "stairwell", attrs.get("is_stairwell")
+                        ),
+                        "is_fire_escape": attrs.get(
+                            "fire_escape", attrs.get("is_fire_escape")
+                        ),
+                    }.items():
+                        if val is not None:
+                            df.at[idx, col] = val
+            return True
         except Exception as e:
             logger.error(f"Error applying learned mappings: {e}")
             return False


### PR DESCRIPTION
## Summary
- call `save_confirmed_device_mappings` from the device confirmation callback
- apply merged learned device mappings in `DoorMappingService`

## Testing
- `black pages/file_upload.py services/door_mapping_service.py`
- `flake8 pages/file_upload.py services/door_mapping_service.py` *(fails: command not found)*
- `mypy pages/file_upload.py services/door_mapping_service.py` *(fails: missing stubs)*
- `python test_modular_system.py` *(fails: file not found)*
- `python tests/test_dashboard.py` *(fails: file not found)*
- `pytest` *(fails: missing pandas and dash)*
- `black . --check` *(fails: many files would be reformatted)*

------
https://chatgpt.com/codex/tasks/task_e_685df7ecc6d083208c9bad50a38c6c30