### PR TITLE
Fix duplicate callback in deep analytics

### DIFF
--- a/pages/deep_analytics.py
+++ b/pages/deep_analytics.py
@@ -589,20 +589,6 @@ def layout():
     [
         Input("security-btn", "n_clicks"),
         Input("trends-btn", "n_clicks"),
-        Input("behavior-btn", "n_clicks"),
-        Input("anomaly-btn", "n_clicks"),
-        Input("suggests-btn", "n_clicks"),
-        Input("quality-btn", "n_clicks"),
-    ],
-    [State("analytics-data-source", "value")],
-    prevent_initial_call=True,
-)
-
-@callback(
-    Output("analytics-display-area", "children"),
-    [
-        Input("security-btn", "n_clicks"),
-        Input("trends-btn", "n_clicks"),
         Input("behavior-btn", "n_clicks"), 
         Input("anomaly-btn", "n_clicks"),
         Input("suggests-btn", "n_clicks"),


### PR DESCRIPTION
## Summary
- remove duplicate callback decorator causing `analytics-display-area.children` duplication

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_685e03b0cf6c832084e38031680e343d