### PR TITLE
Fix dash callback imports

### DIFF
--- a/components/simple_device_mapping.py
+++ b/components/simple_device_mapping.py
@@ -1,6 +1,8 @@
 """Simple manual device mapping component"""
 
-from dash import html, dcc, callback, callback_context
+from dash import html, dcc
+from dash._callback import callback
+from dash._callback_context import callback_context
 from dash.dependencies import Input, Output, State, ALL
 import dash_bootstrap_components as dbc
 from typing import List, Dict, Any


### PR DESCRIPTION
## Summary
- replace dash callback imports with private module to satisfy pylance

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_685e0458c7b88320a55856337ce0a6fc