### PR TITLE
Enhance security analytics

### DIFF
--- a/analytics/security_patterns.py
+++ b/analytics/security_patterns.py
@@ -42,7 +42,12 @@ class SecurityPatternsAnalyzer:
                 'badge_anomalies': self._analyze_badge_anomalies(df),
                 'device_security_issues': self._analyze_device_issues(df),
                 'access_violations': self._analyze_access_violations(df),
+                'failure_breakdown': self._failure_breakdown(df),
+                'trend_over_time': self._trend_over_time(df),
+                'hotspots': self._hotspot_analysis(df),
+                'user_risk_profile': self._user_risk_profile(df),
                 'security_score': self._calculate_security_score(df),
+                'security_score_by_floor': self._calculate_security_score_by_floor(df),
                 'threat_summary': self._generate_threat_summary(df)
             }
             
@@ -300,6 +305,91 @@ class SecurityPatternsAnalyzer:
             'threats': threats,
             'overall_risk': self._assess_overall_risk(threats)
         }
+
+    # New advanced analytics methods
+
+    def _failure_breakdown(self, df: pd.DataFrame) -> Dict[str, Any]:
+        """Break down failures by reason"""
+        failed = df[df['access_result'] == 'Denied']
+        total = len(failed)
+        if total == 0:
+            return {'total': 0, 'breakdown': {}}
+
+        breakdown = {}
+
+        invalid_badge = failed[failed['badge_status'] != 'Valid']
+        breakdown['invalid_badge'] = {
+            'count': len(invalid_badge),
+            'rate': len(invalid_badge) / total * 100,
+        }
+
+        door_jam = failed[failed.get('door_held_open_time', 0) > 30]
+        breakdown['door_jam'] = {
+            'count': len(door_jam),
+            'rate': len(door_jam) / total * 100,
+        }
+
+        timeout = failed[failed.get('device_status') == 'timeout'] if 'device_status' in failed.columns else failed[[]]
+        breakdown['timeout'] = {
+            'count': len(timeout),
+            'rate': len(timeout) / total * 100,
+        }
+
+        other_count = total - sum(v['count'] for v in breakdown.values())
+        if other_count > 0:
+            breakdown['other'] = {
+                'count': other_count,
+                'rate': other_count / total * 100,
+            }
+
+        return {'total': total, 'breakdown': breakdown}
+
+    def _trend_over_time(self, df: pd.DataFrame, freq: str = 'D') -> Dict[str, Any]:
+        """Calculate success vs failure rate trend over time"""
+        df = df.set_index('timestamp')
+        success = (df['access_result'] == 'Granted').resample(freq).mean() * 100
+        failure = (df['access_result'] == 'Denied').resample(freq).mean() * 100
+        return {
+            'frequency': freq,
+            'timestamps': success.index.strftime('%Y-%m-%d').tolist(),
+            'success_rate': success.fillna(0).round(2).tolist(),
+            'failure_rate': failure.fillna(0).round(2).tolist(),
+        }
+
+    def _hotspot_analysis(self, df: pd.DataFrame) -> Dict[str, int]:
+        """Identify doors with the most failures"""
+        failed = df[df['access_result'] == 'Denied']
+        if failed.empty:
+            return {}
+        return failed['door_id'].value_counts().head(10).to_dict()
+
+    def _user_risk_profile(self, df: pd.DataFrame) -> List[Dict[str, Any]]:
+        """Get users with highest failure rates"""
+        grouped = df.groupby('person_id').agg(
+            attempts=('event_id', 'count'),
+            failures=('access_result', lambda x: (x == 'Denied').sum()),
+            tailgating=('entry_without_badge', 'sum') if 'entry_without_badge' in df.columns else ('event_id', lambda x: 0),
+        )
+        grouped['failure_rate'] = grouped['failures'] / grouped['attempts'] * 100
+        high_risk = grouped[grouped['failure_rate'] > 5]
+        high_risk = high_risk.sort_values('failure_rate', ascending=False).head(10)
+        profiles = []
+        for user, row in high_risk.iterrows():
+            profiles.append({
+                'user': user,
+                'failure_rate': round(row['failure_rate'], 2),
+                'tailgating_attempts': int(row['tailgating']),
+            })
+        return profiles
+
+    def _calculate_security_score_by_floor(self, df: pd.DataFrame) -> Dict[str, int]:
+        """Calculate security score per floor if available"""
+        if 'floor_number' not in df.columns:
+            return {}
+        scores = {}
+        for floor, sub in df.groupby('floor_number'):
+            scores[floor] = self._calculate_security_score(sub)
+        return scores
     
     # Helper methods
     def _extract_failure_patterns(self, failed_attempts: pd.DataFrame) -> List[Dict]:
@@ -394,7 +484,12 @@ class SecurityPatternsAnalyzer:
             'badge_anomalies': {'total': 0, 'issues': {}},
             'device_security_issues': {'total': 0, 'issues': {}},
             'access_violations': {'total': 0, 'violation_types': {}},
+            'failure_breakdown': {'total': 0, 'breakdown': {}},
+            'trend_over_time': {},
+            'hotspots': {},
+            'user_risk_profile': [],
             'security_score': 0,
+            'security_score_by_floor': {},
             'threat_summary': {'threat_count': 0, 'threats': []}
         }
 

--- a/pages/deep_analytics.py
+++ b/pages/deep_analytics.py
@@ -739,7 +739,7 @@ def analyze_data_with_service(data_source: str, analysis_type: str) -> Dict[str,
 
         # Generate DIFFERENT results based on analysis type
         if analysis_type == "security":
-            return {
+            result = {
                 "analysis_type": "Security Patterns",
                 "data_source": data_source,
                 "total_events": total_events,
@@ -752,6 +752,21 @@ def analyze_data_with_service(data_source: str, analysis_type: str) -> Dict[str,
                 "date_range": analytics_results.get('date_range', {}),
                 "analysis_focus": "Security threats, failed access attempts, and unauthorized access patterns",
             }
+
+            from pages.file_upload import get_uploaded_data
+            uploaded = get_uploaded_data()
+            df = None
+            if data_source.startswith("upload:"):
+                filename = data_source.replace("upload:", "")
+                df = uploaded.get(filename)
+            elif uploaded:
+                df = list(uploaded.values())[0]
+            if df is not None:
+                from analytics.security_patterns import SecurityPatternsAnalyzer
+                analyzer = SecurityPatternsAnalyzer()
+                result["security_details"] = analyzer.analyze_patterns(df)
+
+            return result
 
         elif analysis_type == "trends":
             return {
@@ -972,11 +987,43 @@ def create_analysis_results_display(results: Dict[str, Any], analysis_type: str)
 
         # Create type-specific content
         if analysis_type == "security":
+            details = results.get('security_details', {})
+            breakdown = details.get('failure_breakdown', {}).get('breakdown', {})
+            hotspots = details.get('hotspots', {})
+            trend = details.get('trend_over_time', {})
+            user_risk = details.get('user_risk_profile', [])
+            floor_scores = details.get('security_score_by_floor', {})
+
+            graphs = []
+            if breakdown:
+                fig = px.bar(x=list(breakdown.keys()), y=[v['count'] for v in breakdown.values()], labels={'x': 'Reason', 'y': 'Count'})
+                graphs.append(dcc.Graph(figure=fig))
+            if trend:
+                trend_fig = go.Figure()
+                trend_fig.add_trace(go.Scatter(x=trend.get('timestamps', []), y=trend.get('success_rate', []), name='Success'))
+                trend_fig.add_trace(go.Scatter(x=trend.get('timestamps', []), y=trend.get('failure_rate', []), name='Failure'))
+                graphs.append(dcc.Graph(figure=trend_fig))
+            if hotspots:
+                hot_fig = px.bar(x=list(hotspots.keys()), y=list(hotspots.values()), labels={'x': 'Door', 'y': 'Failures'})
+                graphs.append(dcc.Graph(figure=hot_fig))
+            if user_risk:
+                user_list = html.Ul([html.Li(f"{u['user']}: {u['failure_rate']:.1f}% fails, tailgating {u['tailgating_attempts']}") for u in user_risk])
+            else:
+                user_list = html.P("No high risk users")
+            if floor_scores:
+                gauges = [html.Div([
+                    html.Span(f"Floor {floor}"),
+                    dbc.Progress(value=score, label=f"{score}")
+                ]) for floor, score in floor_scores.items()]
+            else:
+                gauges = []
+
             specific_content = [
                 html.P(f"Security Score: {results.get('security_score', 0):.1f}/100"),
                 html.P(f"Failed Attempts: {results.get('failed_attempts', 0):,}"),
                 html.P(f"Risk Level: {results.get('risk_level', 'Unknown')}")
-            ]
+            ] + graphs + [user_list] + gauges
+
             color = "danger" if results.get('risk_level') == "High" else "warning" if results.get('risk_level') == "Medium" else "success"
 
         elif analysis_type == "trends":
@@ -1224,14 +1271,43 @@ def analyze_data_with_service_safe(data_source, analysis_type):
         analytics_results = service.get_analytics_by_source(source_name)
         if analytics_results.get('status') == 'error':
             return {"error": analytics_results.get('message', 'Unknown error')}
-        return {
+
+        total_events = analytics_results.get('total_events', 0)
+        success_rate = analytics_results.get('success_rate', 0)
+        if success_rate == 0 and 'successful_events' in analytics_results and total_events:
+            success_rate = analytics_results.get('successful_events', 0) / total_events
+
+        result = {
             "analysis_type": analysis_type.title(),
             "data_source": data_source,
-            "total_events": analytics_results.get('total_events', 0),
+            "total_events": total_events,
             "unique_users": analytics_results.get('unique_users', 0),
-            "success_rate": analytics_results.get('success_rate', 0),
-            "status": "completed"
+            "unique_doors": analytics_results.get('unique_doors', 0),
+            "success_rate": success_rate,
+            "status": "completed",
         }
+
+        if analysis_type == "security":
+            result.update({
+                "security_score": min(100, success_rate * 100 + 20),
+                "failed_attempts": total_events - int(total_events * success_rate),
+                "risk_level": "Low" if success_rate > 0.9 else "Medium" if success_rate > 0.7 else "High",
+            })
+
+            from pages.file_upload import get_uploaded_data
+            uploaded = get_uploaded_data()
+            df = None
+            if data_source.startswith("upload:"):
+                filename = data_source.replace("upload:", "")
+                df = uploaded.get(filename)
+            elif uploaded:
+                df = list(uploaded.values())[0]
+            if df is not None:
+                from analytics.security_patterns import SecurityPatternsAnalyzer
+                analyzer = SecurityPatternsAnalyzer()
+                result["security_details"] = analyzer.analyze_patterns(df)
+
+        return result
     except Exception as e:
         return {"error": f"Service analysis failed: {str(e)}"}
 
@@ -1270,6 +1346,55 @@ def create_analysis_results_display_safe(results, analysis_type):
                 html.P(f"Unique users: {results.get('unique_users', 0):,}"),
                 html.P(f"Success rate: {results.get('success_rate', 0):.1%}")
             ])
+            if analysis_type == "security":
+                details = results.get('security_details', {})
+                breakdown = details.get('failure_breakdown', {}).get('breakdown', {})
+                trend = details.get('trend_over_time', {})
+                hotspots = details.get('hotspots', {})
+                user_risk = details.get('user_risk_profile', [])
+                floor_scores = details.get('security_score_by_floor', {})
+
+                graphs = []
+                if breakdown:
+                    fig = px.bar(x=list(breakdown.keys()), y=[v['count'] for v in breakdown.values()],
+                                 labels={'x': 'Reason', 'y': 'Count'})
+                    graphs.append(dcc.Graph(figure=fig))
+                if trend:
+                    trend_fig = go.Figure()
+                    trend_fig.add_trace(go.Scatter(x=trend.get('timestamps', []), y=trend.get('success_rate', []), name='Success'))
+                    trend_fig.add_trace(go.Scatter(x=trend.get('timestamps', []), y=trend.get('failure_rate', []), name='Failure'))
+                    graphs.append(dcc.Graph(figure=trend_fig))
+                if hotspots:
+                    hot_fig = px.bar(x=list(hotspots.keys()), y=list(hotspots.values()),
+                                     labels={'x': 'Door', 'y': 'Failures'})
+                    graphs.append(dcc.Graph(figure=hot_fig))
+                if user_risk:
+                    user_list = html.Ul([
+                        html.Li(f"{u['user']}: {u['failure_rate']:.1f}% fails, tailgating {u['tailgating_attempts']}")
+                        for u in user_risk
+                    ])
+                else:
+                    user_list = html.P("No high risk users")
+                if floor_scores:
+                    gauges = [html.Div([
+                        html.Span(f"Floor {floor}"),
+                        dbc.Progress(value=score, label=f"{score}")
+                    ]) for floor, score in floor_scores.items()]
+                else:
+                    gauges = []
+
+                content.extend(
+                    [
+                        html.P(
+                            f"Security Score: {details.get('security_score', results.get('security_score', 0)):.1f}/100"
+                        ),
+                        html.P(f"Failed Attempts: {results.get('failed_attempts', 0):,}"),
+                        html.P(f"Risk Level: {results.get('risk_level', 'Unknown')}")
+                    ]
+                    + graphs
+                    + [user_list]
+                    + gauges
+                )
         return dbc.Card([
             dbc.CardBody(content)
         ])


### PR DESCRIPTION
## Summary
- add advanced analytics results when analyzing security data in safe mode
- display new metrics with graphs, user lists, and floor gauges in the security panel

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_685e13d3c7808320bb088970e3f8dbd5