### PR TITLE
Fix type hints for EnhancedColumnClassifier

### DIFF
--- a/services/enhanced_column_classifier.py
+++ b/services/enhanced_column_classifier.py
@@ -17,8 +17,8 @@ class EnhancedColumnClassifier:
         self.model_path = Path(model_path)
         self.vectorizer_path = Path("data/column_vectorizer.joblib")
         self.confidence_threshold = confidence_threshold
-        self.classifier = None
-        self.vectorizer = None
+        self.classifier: Optional[Any] = None
+        self.vectorizer: Optional[Any] = None
         self.logger = logging.getLogger(__name__)
 
         # Standard field patterns for heuristic fallback
@@ -62,6 +62,8 @@ class EnhancedColumnClassifier:
         method = "ml_with_fallback"
 
         try:
+            assert self.vectorizer is not None, "Vectorizer is not loaded"
+            assert self.classifier is not None, "Classifier is not loaded"
             features = self.vectorizer.transform(headers)
             predictions = self.classifier.predict_proba(features)
 


### PR DESCRIPTION
## Summary
- specify classifier and vectorizer as optional types
- guard access to model objects with assertions

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_685e4b0284dc8320b434b32db5ba672b