### PR TITLE
Fix import for config manager

### DIFF
--- a/database/connection.py
+++ b/database/connection.py
@@ -24,9 +24,9 @@ class DatabaseConnection(Protocol):
 def create_database_connection() -> DatabaseConnection:
     """Create database connection using existing DatabaseManager"""
     # Use your existing database manager
-    from config.config import get_configuration_manager
+    from config.config import get_config
 
-    config_manager = get_configuration_manager()
+    config_manager = get_config()
     db_config = config_manager.get_database_config()
 
     # Create database manager with existing config


### PR DESCRIPTION
## Summary
- replace old get_configuration_manager call with get_config

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_685e529ac6048320b368f19074cee09a