### PR TITLE
Fix ConfigManager import

### DIFF
--- a/core/plugins/manager.py
+++ b/core/plugins/manager.py
@@ -10,7 +10,7 @@ from core.plugins.protocols import (
 )
 
 from core.container import Container as DIContainer
-from config.config import ConfigurationManager
+from config.config import ConfigManager
 
 
 logger = logging.getLogger(__name__)


### PR DESCRIPTION
## Summary
- update import for configuration manager

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'services')*

------
https://chatgpt.com/codex/tasks/task_e_685e52a5ee588320bc08040f1295a475