### PR TITLE
Fix ConfigManager name in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,7 +171,7 @@ secrets.
 
 ### Environment Overrides
 
-`ConfigurationManager` loads YAML files from `config/` and then checks for
+`ConfigManager` loads YAML files from `config/` and then checks for
 environment variables. When a variable name matches a key used in the YAML
 configuration (for example `DB_HOST`, `DB_USER`, `REDIS_HOST` or
 `SECRET_KEY`), its value replaces the one from the file. This lets you adjust


### PR DESCRIPTION
## Summary
- correct the class name under the Environment Overrides section

## Testing
- `pytest -q` *(fails: ModuleNotFoundError for several packages)*

------
https://chatgpt.com/codex/tasks/task_e_685e52ac210c8320a87033d0e7cfd7a1