### PR TITLE
Make analytics input files configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,6 +169,18 @@ When `YOSAI_ENV=production` the application will refuse to start unless both
 `DB_PASSWORD` and `SECRET_KEY` are provided via environment variables or Docker
 secrets.
 
+### Analytics Data Files
+
+The optional fixed processor analytics rely on sample CSV and JSON files. Set
+the paths to these files via environment variables:
+
+```bash
+ANALYTICS_CSV_FILE=/path/to/data.csv
+ANALYTICS_JSON_FILE=/path/to/data.json
+```
+
+If either variable is unset the fixed processor step is skipped.
+
 ### Environment Overrides
 
 `ConfigManager` loads YAML files from `config/` and then checks for

--- a/services/analytics_service.py
+++ b/services/analytics_service.py
@@ -540,8 +540,14 @@ class AnalyticsService:
     def _get_analytics_with_fixed_processor(self) -> Dict[str, Any]:
         """Get analytics using the FIXED file processor"""
 
-        csv_file = "/Users/tombrayman/Library/CloudStorage/Dropbox/1. YOSAI CODING/03_Data/Datasets/Demo3_data.csv"
-        json_file = "/Users/tombrayman/Library/CloudStorage/Dropbox/1. YOSAI CODING/03_Data/Datasets/key_fob_access_log_sample.json"
+        csv_file = os.getenv("ANALYTICS_CSV_FILE")
+        json_file = os.getenv("ANALYTICS_JSON_FILE")
+
+        if not csv_file or not json_file:
+            logger.debug(
+                "Analytics file paths not set; skipping fixed processor analytics"
+            )
+            return {"status": "no_data", "message": "File paths not configured"}
 
         try:
             from services.file_processor import FileProcessor


### PR DESCRIPTION
## Summary
- let `_get_analytics_with_fixed_processor` read file paths from environment variables
- document `ANALYTICS_CSV_FILE` and `ANALYTICS_JSON_FILE` in README

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'services', etc.)*
- `mypy .` *(fails: Duplicate module named "production_setup")*
- `black . --check` *(fails: would reformat many files)*
- `flake8 .` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685e57171710832099250512a3a4aea6