### PR TITLE
Update plugin docs and training instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ An AI-powered modular security intelligence dashboard for physical access contro
 
 ## 🏗️ Modular Architecture
 
-This project follows a fully modular architecture for maximum maintainability and testability. See [docs/architecture.md](docs/architecture.md) for an overview diagram. Additional flow diagrams are provided in [docs/data_flow.md](docs/data_flow.md) and [docs/plugin_architecture.md](docs/plugin_architecture.md):
+This project follows a fully modular architecture for maximum maintainability and testability. See [docs/architecture.md](docs/architecture.md) for an overview diagram. Additional flow diagrams are provided in [docs/data_flow.md](docs/data_flow.md), [docs/plugin_architecture.md](docs/plugin_architecture.md), and the new [docs/system_diagram.md](docs/system_diagram.md):
 
 ```
 yosai_intel_dashboard/
@@ -207,6 +207,12 @@ YOSAI_ENV=production python app.py
 YOSAI_CONFIG_FILE=/path/to/custom.yaml python app.py
 ```
 
+### Plugins
+
+Plugins live in the `plugins/` package and are loaded by the `PluginManager` when enabled in `config/config.yaml`.
+To enable a plugin, add it under the `plugins:` section and set `enabled: true`.
+After creating the `PluginManager` in your app factory, call `load_all_plugins()` and `register_plugin_callbacks(app)` to activate them.
+
 ## 📊 Modular Components
 
 ### Database Layer (`config/`)
@@ -254,10 +260,10 @@ If you encounter an error like `"Babel" object has no attribute "localeselector"
 
 ## 🤝 Contributing
 
-1. Ensure all tests pass: `python test_modular_system.py`
-2. Follow type safety guidelines
-3. Maintain modular architecture principles
-4. Update documentation for new features
+1. Ensure all tests pass: `python test_modular_system.py` and `pytest`
+2. Format code with `black` and run `flake8`
+3. Follow type safety guidelines and maintain the modular architecture
+4. Add tests for new functionality and update documentation when applicable
 
 ## 📄 License
 

--- a/docs/column_mapping_ml.md
+++ b/docs/column_mapping_ml.md
@@ -1,12 +1,21 @@
 # Machine-Learned Column Mapping
 
 The column mapper can leverage a supervised model to recognize common header variations.
-The provided training script expects a CSV file with `header` and `label` columns.
-Run the following to train a new model:
+Prepare a CSV file with `header` and `label` columns and train a simple model using scikit-learn:
 
-```bash
-python scripts/train_column_classifier.py training_data.csv
+```python
+import joblib
+import pandas as pd
+from sklearn.feature_extraction.text import CountVectorizer
+from sklearn.naive_bayes import MultinomialNB
+
+training = pd.read_csv('training_data.csv')
+vectorizer = CountVectorizer()
+X = vectorizer.fit_transform(training['header'])
+clf = MultinomialNB()
+clf.fit(X, training['label'])
+joblib.dump(clf, 'data/column_model.joblib')
+joblib.dump(vectorizer, 'data/column_vectorizer.joblib')
 ```
 
-This creates `data/column_model.joblib` and `data/column_vectorizer.joblib` used by
-`ColumnMappingService` when `learning_enabled` is enabled in the configuration.
+These files will be loaded by `ColumnMappingService` when `learning_enabled` is enabled in the configuration.

--- a/docs/system_diagram.md
+++ b/docs/system_diagram.md
@@ -1,0 +1,14 @@
+# System Flow Diagram
+
+This diagram illustrates how the Dash pages interact with the service layer, plugins, and the database.
+
+```mermaid
+flowchart TD
+    Browser -->|HTTP| Pages["Dash Pages"]
+    Pages -->|Calls| Services
+    Services -->|Queries| DB[(Database)]
+    Services --> PluginManager
+    PluginManager --> Plugins
+    Plugins -->|Register callbacks| Pages
+```
+


### PR DESCRIPTION
## Summary
- document new system diagram
- improve plugin usage instructions
- explain how to train the column mapping model
- clarify contribution guidelines

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*
- `black . --check` *(fails: would reformat many files)*
- `flake8 .` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685e56e0b80883209e10174d47380a05