### PR TITLE
Update config secrets to env vars

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,6 +165,18 @@ PORT=8050            # Application port
 SECRET_KEY=your-key  # Change for production
 ```
 
+### Required Environment Variables
+
+These variables **must** be provided in production, either via `.env` or your
+shell environment:
+
+```bash
+SECRET_KEY=<your secret key>
+DB_PASSWORD=<database password>
+```
+The application will not start in production if these contain placeholder
+values.
+
 When `YOSAI_ENV=production` the application will refuse to start unless both
 `DB_PASSWORD` and `SECRET_KEY` are provided via environment variables or Docker
 secrets.

--- a/config/config.py
+++ b/config/config.py
@@ -205,9 +205,13 @@ class ConfigManager:
             if self.config.app.host == "127.0.0.1":
                 warnings.append("Production should not run on localhost")
         
-        # Log warnings
-        for warning in warnings:
-            logger.warning(f"Configuration warning: {warning}")
+        # Log warnings or fail fast in production
+        if warnings:
+            if self.config.environment == "production":
+                joined = "; ".join(warnings)
+                raise RuntimeError(f"Invalid production configuration: {joined}")
+            for warning in warnings:
+                logger.warning(f"Configuration warning: {warning}")
     
     def get_app_config(self) -> AppConfig:
         """Get app configuration"""

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -14,7 +14,7 @@ database:
   max_overflow: 20
 
 security:
-  secret_key: "your-secret-key-here"
+  secret_key: "${SECRET_KEY}"
   session_timeout: 3600
   csrf_enabled: false
 

--- a/config/test.yaml
+++ b/config/test.yaml
@@ -11,10 +11,10 @@ database:
   port: 5432
   name: "yosai_db"
   user: "yosai_user"
-  password: "change-me"
+  password: "${DB_PASSWORD}"
 
 security:
-  secret_key: "change-me"
+  secret_key: "${SECRET_KEY}"
   session_timeout: 3600
 
 analytics:


### PR DESCRIPTION
## Summary
- use environment variables for secrets in config files
- fail fast in production if default secrets detected
- document required environment variables in README

## Testing
- `pytest -q`
- `flake8` *(fails: command not found)*
- `black --check .` *(fails: would reformat many files)*
- `mypy .`


------
https://chatgpt.com/codex/tasks/task_e_685e5d745be88320b7de0e0dafeba536