### PR TITLE
Fix Dash callback imports

### DIFF
--- a/components/device_verification.py
+++ b/components/device_verification.py
@@ -1,8 +1,7 @@
 """Device verification component - follows exact same pattern as column_verification.py"""
 
 import pandas as pd
-from dash import html, dcc
-from dash._callback import callback
+from dash import html, dcc, callback
 from dash.dependencies import Input, Output, State, ALL, MATCH
 import dash
 import dash_bootstrap_components as dbc

--- a/components/simple_device_mapping.py
+++ b/components/simple_device_mapping.py
@@ -1,8 +1,6 @@
 """Simple manual device mapping component"""
 
-from dash import html, dcc
-from dash._callback import callback
-from dash._callback_context import callback_context
+from dash import html, dcc, callback, callback_context
 from dash.dependencies import Input, Output, State, ALL
 import dash_bootstrap_components as dbc
 from typing import List, Dict, Any

--- a/dashboard/layout/navbar.py
+++ b/dashboard/layout/navbar.py
@@ -10,15 +10,13 @@ from core.plugins.decorators import safe_callback
 # Type checking imports
 if TYPE_CHECKING:
     import dash_bootstrap_components as dbc
-    from dash import html, dcc
-    from dash._callback import callback
+    from dash import html, dcc, callback
     from dash.dependencies import Output, Input
 
 # Runtime imports with proper fallbacks
 try:
     import dash_bootstrap_components as dbc
-    from dash import html, dcc
-    from dash._callback import callback
+    from dash import html, dcc, callback
     from dash.dependencies import Output, Input
     DASH_AVAILABLE = True
 except ImportError:

--- a/pages/file_upload.py
+++ b/pages/file_upload.py
@@ -12,8 +12,7 @@ import pandas as pd
 from typing import Optional, Dict, Any, List
 from dash import html, dcc
 from dash.dash import no_update
-from dash._callback import callback
-from dash._callback_context import callback_context
+from dash import callback, callback_context
 from dash.dependencies import Input, Output, State, ALL
 import dash_bootstrap_components as dbc
 from services.device_learning_service import DeviceLearningService

--- a/services/device_learning_service.py
+++ b/services/device_learning_service.py
@@ -5,11 +5,9 @@ from typing import Dict, Any, Optional
 from pathlib import Path
 from datetime import datetime
 import pandas as pd
-from dash import html
-from dash._callback import callback
+from dash import html, callback, callback_context
 from dash.dependencies import Input, Output
 from services.consolidated_learning_service import get_learning_service
-from dash._callback_context import callback_context
 
 logger = logging.getLogger(__name__)
 


### PR DESCRIPTION
## Summary
- swap private callback imports for public ones in UI modules

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685e6bf01e84832085daacd6970e7da0