### PR TITLE
Fix file upload parsing

### DIFF
--- a/tests/test_upload_utils.py
+++ b/tests/test_upload_utils.py
@@ -1,0 +1,37 @@
+import base64
+import pytest
+
+pd = pytest.importorskip("pandas")
+from services.upload_utils import parse_uploaded_file
+
+
+def _to_data_url(text: str, mime: str) -> str:
+    encoded = base64.b64encode(text.encode("utf-8")).decode("utf-8")
+    return f"data:{mime};base64,{encoded}"
+
+
+def test_parse_csv_upload() -> None:
+    csv = "a,b\n1,2\n3,4\n"
+    contents = _to_data_url(csv, "text/csv")
+    result = parse_uploaded_file(contents, "test.csv")
+    assert result["success"] is True
+    df = result["data"]
+    assert isinstance(df, pd.DataFrame)
+    assert list(df.columns) == ["a", "b"]
+    assert len(df) == 2
+
+
+def test_parse_json_upload() -> None:
+    json_text = '[{"a":1,"b":2},{"a":3,"b":4}]'
+    contents = _to_data_url(json_text, "application/json")
+    result = parse_uploaded_file(contents, "data.json")
+    assert result["success"] is True
+    df = result["data"]
+    assert list(df.columns) == ["a", "b"]
+    assert len(df) == 2
+
+
+def test_invalid_upload() -> None:
+    contents = "data:text/csv;base64,invalid"
+    result = parse_uploaded_file(contents, "bad.csv")
+    assert result["success"] is False

--- a/utils/file_validator.py
+++ b/utils/file_validator.py
@@ -1,10 +1,12 @@
 """
 Simple file validation utilities
 """
+
 import pandas as pd
 import io
 import base64
 from typing import Dict, Any, Optional, Tuple
+from services.file_processor_service import FileProcessorService
 
 
 def validate_upload_content(contents: str, filename: str) -> Dict[str, Any]:
@@ -15,20 +17,20 @@ def validate_upload_content(contents: str, filename: str) -> Dict[str, Any]:
         return {"valid": False, "error": "Missing file content or filename"}
 
     # Check if contents is properly formatted
-    if not contents.startswith('data:'):
+    if not contents.startswith("data:"):
         return {"valid": False, "error": "Invalid file format - not a data URL"}
 
-    if ',' not in contents:
+    if "," not in contents:
         return {"valid": False, "error": "Invalid file format - missing data separator"}
 
     # Check file extension
-    allowed_extensions = {'.csv', '.json', '.xlsx', '.xls'}
-    file_ext = '.' + filename.split('.')[-1].lower() if '.' in filename else ''
+    allowed_extensions = {".csv", ".json", ".xlsx", ".xls"}
+    file_ext = "." + filename.split(".")[-1].lower() if "." in filename else ""
 
     if file_ext not in allowed_extensions:
         return {
             "valid": False,
-            "error": f"File type {file_ext} not supported. Allowed: {', '.join(allowed_extensions)}"
+            "error": f"File type {file_ext} not supported. Allowed: {', '.join(allowed_extensions)}",
         }
 
     return {"valid": True, "extension": file_ext}
@@ -38,10 +40,10 @@ def safe_decode_file(contents: str) -> Optional[bytes]:
     """Safely decode base64 file contents"""
     try:
         # Split the data URL
-        if ',' not in contents:
+        if "," not in contents:
             return None
 
-        content_type, content_string = contents.split(',', 1)
+        content_type, content_string = contents.split(",", 1)
 
         # Decode base64
         decoded = base64.b64decode(content_string)
@@ -51,36 +53,17 @@ def safe_decode_file(contents: str) -> Optional[bytes]:
         return None
 
 
-def process_dataframe(decoded: bytes, filename: str) -> Tuple[Optional[pd.DataFrame], Optional[str]]:
-    """Process decoded bytes into DataFrame"""
+def process_dataframe(
+    decoded: bytes, filename: str
+) -> Tuple[Optional[pd.DataFrame], Optional[str]]:
+    """Process decoded bytes into DataFrame using :class:`FileProcessorService`."""
+    processor = FileProcessorService()
     try:
-        filename_lower = filename.lower()
+        file_validation = processor.validate_file(filename, decoded)
+        if not file_validation.get("valid"):
+            return None, "; ".join(file_validation.get("issues", []))
 
-        if filename_lower.endswith('.csv'):
-            # Try multiple encodings
-            for encoding in ['utf-8', 'latin-1', 'cp1252']:
-                try:
-                    df = pd.read_csv(io.StringIO(decoded.decode(encoding)))
-                    return df, None
-                except UnicodeDecodeError:
-                    continue
-            return None, "Could not decode CSV with any standard encoding"
-
-        elif filename_lower.endswith('.json'):
-            import json
-            json_data = json.loads(decoded.decode('utf-8'))
-            if isinstance(json_data, list):
-                df = pd.DataFrame(json_data)
-            else:
-                df = pd.DataFrame([json_data])
-            return df, None
-
-        elif filename_lower.endswith(('.xlsx', '.xls')):
-            df = pd.read_excel(io.BytesIO(decoded))
-            return df, None
-
-        else:
-            return None, f"Unsupported file type: {filename}"
-
-    except Exception as e:
+        df = processor.process_file(decoded, filename)
+        return df, None
+    except Exception as e:  # pragma: no cover - unexpected processing error
         return None, f"Error processing file: {str(e)}"


### PR DESCRIPTION
## Summary
- switch upload utils to use FileProcessorService
- refactor file validator to reuse FileProcessorService
- add tests for CSV and JSON uploads

## Testing
- `pytest`
- `mypy services/upload_utils.py utils/file_validator.py tests/test_upload_utils.py`
- `black . --check` *(fails: 127 files would be reformatted)*
- `flake8 .` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685e754fed9483208571f32e3e25584a