### PR TITLE
Fix upload util test import path

### DIFF
--- a/tests/test_upload_utils.py
+++ b/tests/test_upload_utils.py
@@ -1,5 +1,13 @@
 import base64
+from pathlib import Path
+import sys
 import pytest
+
+# Ensure the project root is on the Python path when executing the
+# test file directly.  This mirrors the behaviour in ``conftest.py``
+# and other test modules so that ``services`` can be imported even if
+# the current working directory is ``tests``.
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 
 pd = pytest.importorskip("pandas")
 from services.upload_utils import parse_uploaded_file


### PR DESCRIPTION
## Summary
- ensure `services` can be imported when running tests directly

## Testing
- `pytest -q tests/test_upload_utils.py`

------
https://chatgpt.com/codex/tasks/task_e_685e775bf6408320bb90e8d25b6da535