### PR TITLE
Improve Unicode handling

### DIFF
--- a/tests/test_text_utils.py
+++ b/tests/test_text_utils.py
@@ -1,0 +1,21 @@
+import importlib.util
+import pathlib
+
+spec = importlib.util.spec_from_file_location(
+    "text_utils", pathlib.Path(__file__).resolve().parents[1] / "utils" / "text_utils.py"
+)
+text_utils = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(text_utils)
+
+sanitize_text_for_dash = text_utils.sanitize_text_for_dash
+remove_invalid_unicode = text_utils.remove_invalid_unicode
+
+
+def test_remove_invalid_unicode():
+    bad_text = "hello\udcffworld"
+    assert remove_invalid_unicode(bad_text) == "helloworld"
+
+
+def test_sanitize_text_for_dash_removes_surrogates():
+    text = "a\ud800b"
+    assert sanitize_text_for_dash(text) == "ab"

--- a/utils/text_utils.py
+++ b/utils/text_utils.py
@@ -25,6 +25,11 @@ def safe_text(text: Union[str, Any]) -> str:
     return repr(text)
 
 
+def remove_invalid_unicode(text: str) -> str:
+    """Remove surrogate code points that can't be encoded to UTF-8"""
+    return "".join(ch for ch in text if not (0xD800 <= ord(ch) <= 0xDFFF))
+
+
 def sanitize_text_for_dash(text: Union[str, Any]) -> str:
     """
     Sanitize text specifically for Dash components
@@ -36,11 +41,12 @@ def sanitize_text_for_dash(text: Union[str, Any]) -> str:
         str: Dash-safe text
     """
     safe_str = safe_text(text)
-    
+
     # Remove any problematic characters that might cause JSON issues
     safe_str = safe_str.replace('\x00', '')  # Remove null bytes
     safe_str = safe_str.replace('\ufeff', '')  # Remove BOM
-    
+    safe_str = remove_invalid_unicode(safe_str)
+
     return safe_str
 
 
@@ -84,4 +90,10 @@ def truncate_text(text: str, max_length: int = 100, suffix: str = "...") -> str:
     return text[:max_length - len(suffix)] + suffix
 
 
-__all__ = ["safe_text", "sanitize_text_for_dash", "format_file_size", "truncate_text"]
+__all__ = [
+    "safe_text",
+    "remove_invalid_unicode",
+    "sanitize_text_for_dash",
+    "format_file_size",
+    "truncate_text",
+]


### PR DESCRIPTION
## Summary
- add `remove_invalid_unicode` to remove surrogate characters before Flask encodes text
- sanitize dash text via new helper
- test text utility helper with surrogate characters

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685f0464b9248320a349a0e94a89835d