### PR TITLE
Fix global callbacks to register uploads

### DIFF
--- a/core/app_factory.py
+++ b/core/app_factory.py
@@ -331,6 +331,11 @@ def _register_global_callbacks(app: dash.Dash) -> None:
     except ImportError as e:
         logger.warning(f"Device learning callbacks not available: {e}")
 
+    # Execute upload page callbacks via module import
+    import pages.file_upload  # This executes the @callback decorators
+
+    logger.info("✅ Global callbacks registered successfully")
+
 
 def _initialize_services() -> None:
     """Initialize all application services"""


### PR DESCRIPTION
## Summary
- register upload callbacks in global callback registration

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685f138648a883209cc6c925f4b5cfec